### PR TITLE
Add typescript-eslint to server

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,1 @@
-{ "printWidth": 200 }
+{ "printWidth": 200, "singleQuote": true }

--- a/api/.eslintignore
+++ b/api/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/api/.eslintrc.js
+++ b/api/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+};

--- a/api/.eslintrc.js
+++ b/api/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   root: true,
-  parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint"],
-  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
 };

--- a/api/.eslintrc.js
+++ b/api/.eslintrc.js
@@ -1,6 +1,9 @@
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'prettier'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  rules: {
+    'prettier/prettier': 'warn', // TODO: Convert to error later
+  },
 };

--- a/api/.prettierignore
+++ b/api/.prettierignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
+  preset: 'ts-jest',
+  testEnvironment: 'node',
 };

--- a/api/package.json
+++ b/api/package.json
@@ -11,7 +11,8 @@
     "clean": "rm -rf build/",
     "test": "jest",
     "test:watch": "jest --watch",
-    "format": "prettier --config ../.prettierrc --ignore-path .prettierignore --write \"src/**/*\""
+    "format": "prettier --config ../.prettierrc --ignore-path .prettierignore --write .",
+    "lint": "eslint src --ext .js,.ts"
   },
   "author": "",
   "license": "ISC",
@@ -19,6 +20,9 @@
     "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.11",
     "@types/jest": "^26.0.23",
+    "@typescript-eslint/eslint-plugin": "^4.24.0",
+    "@typescript-eslint/parser": "^4.24.0",
+    "eslint": "^7.27.0",
     "jest": "^26.6.3",
     "nodemon": "^2.0.7",
     "prettier": "^2.3.0",

--- a/api/package.json
+++ b/api/package.json
@@ -23,6 +23,7 @@
     "@typescript-eslint/eslint-plugin": "^4.24.0",
     "@typescript-eslint/parser": "^4.24.0",
     "eslint": "^7.27.0",
+    "eslint-plugin-prettier": "^3.4.0",
     "jest": "^26.6.3",
     "nodemon": "^2.0.7",
     "prettier": "^2.3.0",

--- a/api/package.json
+++ b/api/package.json
@@ -10,7 +10,8 @@
     "build": "npm run clean && tsc",
     "clean": "rm -rf build/",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "format": "prettier --config ../.prettierrc --ignore-path .prettierignore --write \"src/**/*\""
   },
   "author": "",
   "license": "ISC",

--- a/api/src/controllers/sample.ts
+++ b/api/src/controllers/sample.ts
@@ -1,12 +1,12 @@
-import { Request, Response, NextFunction } from "express";
-import logging from "../util/logging";
+import { Request, Response, NextFunction } from 'express';
+import logging from '../util/logging';
 
-const NAMESPACE = "Sample Controller";
+const NAMESPACE = 'Sample Controller';
 
 const sampleHealthCheck = (req: Request, res: Response, next: NextFunction) => {
-  logging.info(NAMESPACE, "Sample health check route called.");
+  logging.info(NAMESPACE, 'Sample health check route called.');
 
-  return res.status(200).json({ message: "pong" });
+  return res.status(200).json({ message: 'pong' });
 };
 
 export default { sampleHealthCheck };

--- a/api/src/routes/middleware.test.ts
+++ b/api/src/routes/middleware.test.ts
@@ -1,8 +1,8 @@
-import middleware from "./middleware";
-import { NextFunction, Request, Response } from "express";
-import logging from "../util/logging";
+import middleware from './middleware';
+import { NextFunction, Request, Response } from 'express';
+import logging from '../util/logging';
 
-describe("notFound middleware", () => {
+describe('notFound middleware', () => {
   let mockRequest: Partial<Request>;
   let mockResponse: Partial<Response>;
   let nextFunction: NextFunction;
@@ -15,9 +15,9 @@ describe("notFound middleware", () => {
     nextFunction = jest.fn();
   });
 
-  it("always returns 404", () => {
+  it('always returns 404', () => {
     const expectedResponse = {
-      message: "not found",
+      message: 'not found',
     };
     middleware.notFound(mockRequest as Request, mockResponse as Response, nextFunction);
 
@@ -25,39 +25,39 @@ describe("notFound middleware", () => {
     expect(mockResponse.status).toBeCalledWith(404);
   });
 
-  it("does not call further middleware", () => {
+  it('does not call further middleware', () => {
     middleware.notFound(mockRequest as Request, mockResponse as Response, nextFunction);
 
     expect(nextFunction).toBeCalledTimes(0);
   });
 });
 
-describe("logRequest middleware", () => {
+describe('logRequest middleware', () => {
   let mockRequest: Partial<Request>;
   let mockResponse: Partial<Response>;
   let nextFunction: NextFunction;
 
   beforeEach(() => {
     mockRequest = {};
-    mockRequest.url = "/api/v1/ping";
-    mockRequest.method = "GET";
+    mockRequest.url = '/api/v1/ping';
+    mockRequest.method = 'GET';
     mockResponse = {};
     mockResponse.on = jest.fn();
     nextFunction = jest.fn();
     logging.info = jest.fn();
   });
 
-  it("logs start of request", () => {
+  it('logs start of request', () => {
     middleware.logRequest(mockRequest as Request, mockResponse as Response, nextFunction);
     expect(logging.info).toBeCalledTimes(1);
-    expect(logging.info).toBeCalledWith("Server", "METHOD - [GET], URL - [/api/v1/ping]");
+    expect(logging.info).toBeCalledWith('Server', 'METHOD - [GET], URL - [/api/v1/ping]');
   });
 
-  it("logs end of request", () => {
+  it('logs end of request', () => {
     // TODO I don't know how to test this yet
   });
 
-  it("calls next middleware", () => {
+  it('calls next middleware', () => {
     middleware.logRequest(mockRequest as Request, mockResponse as Response, nextFunction);
 
     expect(nextFunction).toBeCalledTimes(1);

--- a/api/src/routes/middleware.ts
+++ b/api/src/routes/middleware.ts
@@ -1,7 +1,7 @@
-import { NextFunction, Request, Response } from "express";
-import logging from "../util/logging";
+import { NextFunction, Request, Response } from 'express';
+import logging from '../util/logging';
 
-const NAMESPACE = "Server";
+const NAMESPACE = 'Server';
 
 /**
  * Log the request.
@@ -14,7 +14,7 @@ function logRequest(req: Request, res: Response, next: NextFunction): void {
   const message = `METHOD - [${req.method}], URL - [${req.url}]`;
   logging.info(NAMESPACE, message);
 
-  res.on("finish", () => {
+  res.on('finish', () => {
     logging.info(NAMESPACE, `${message}, STATUS - [${res.statusCode}]`);
   });
 
@@ -29,7 +29,7 @@ function logRequest(req: Request, res: Response, next: NextFunction): void {
  * @returns
  */
 function notFound(req: Request, res: Response, next: NextFunction): void {
-  const error = new Error("not found");
+  const error = new Error('not found');
 
   res.status(404).json({ message: error.message });
 }

--- a/api/src/routes/sample.ts
+++ b/api/src/routes/sample.ts
@@ -1,8 +1,8 @@
-import express from "express";
-import controller from "../controllers/sample";
+import express from 'express';
+import controller from '../controllers/sample';
 
 const router = express.Router();
 
-router.get("/ping", controller.sampleHealthCheck);
+router.get('/ping', controller.sampleHealthCheck);
 
 export = router;

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,11 +1,11 @@
-import http from "http";
-import express from "express";
-import logging from "./util/logging";
-import config from "./util/config";
-import sampleRoutes from "./routes/sample";
-import middleware from "./routes/middleware";
+import http from 'http';
+import express from 'express';
+import logging from './util/logging';
+import config from './util/config';
+import sampleRoutes from './routes/sample';
+import middleware from './routes/middleware';
 
-const NAMESPACE = "Server";
+const NAMESPACE = 'Server';
 const router = express();
 
 /** Log the request */
@@ -15,7 +15,7 @@ router.use(middleware.logRequest);
 router.use(express.json());
 
 /** Routes */
-router.use("/api/v1", sampleRoutes);
+router.use('/api/v1', sampleRoutes);
 
 /** Error handling */
 router.use(middleware.notFound);

--- a/api/src/util/config.ts
+++ b/api/src/util/config.ts
@@ -1,8 +1,8 @@
-import dotenv from "dotenv";
+import dotenv from 'dotenv';
 
 dotenv.config();
 
-const SERVER_HOSTNAME = process.env.SERVER_HOSTNAME || "localhost";
+const SERVER_HOSTNAME = process.env.SERVER_HOSTNAME || 'localhost';
 const SERVER_PORT = process.env.SERVER_PORT || 1337;
 
 const SERVER = {

--- a/api/src/util/logging.ts
+++ b/api/src/util/logging.ts
@@ -32,7 +32,7 @@ function log(level: string, namespace: string, message: string, object?: any) {
  * @param object Optional object to add to log.
  */
 function info(namespace: string, message: string, object?: any) {
-  log("INFO", namespace, message, object);
+  log('INFO', namespace, message, object);
 }
 
 /**
@@ -42,7 +42,7 @@ function info(namespace: string, message: string, object?: any) {
  * @param object Optional object to add to log.
  */
 function warn(namespace: string, message: string, object?: any) {
-  log("WARN", namespace, message, object);
+  log('WARN', namespace, message, object);
 }
 
 /**
@@ -52,7 +52,7 @@ function warn(namespace: string, message: string, object?: any) {
  * @param object Optional object to add to log.
  */
 function error(namespace: string, message: string, object?: any) {
-  log("ERROR", namespace, message, object);
+  log('ERROR', namespace, message, object);
 }
 
 /**
@@ -62,7 +62,7 @@ function error(namespace: string, message: string, object?: any) {
  * @param object Optional object to add to log.
  */
 function debug(namespace: string, message: string, object?: any) {
-  log("DEBUG", namespace, message, object);
+  log('DEBUG', namespace, message, object);
 }
 
 export default {

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -4,8 +4,8 @@
 
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
-    "target": "es5",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
@@ -14,7 +14,7 @@
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    "outDir": "./build",                              /* Redirect output structure to the directory. */
+    "outDir": "./build" /* Redirect output structure to the directory. */,
     // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
@@ -25,7 +25,7 @@
     // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                                 /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                    /* Enable strict null checks. */
     // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
@@ -50,7 +50,7 @@
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
     // "types": [],                                 /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
 
@@ -65,7 +65,7 @@
     // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "skipLibCheck": true,                           /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
+    "skipLibCheck": true /* Skip type checking of declaration files. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   }
 }


### PR DESCRIPTION
- Add `typescript-eslint` for server linting (ensures no unused variables, etc.)
- Use single quotes for prettier
  - Run format on `src/`
- Eslint will warn on formatting violations
- Server's eslint and client's eslint should be separated because they'll use different plugins (e.g. the front end stuff will use eslint-react)