### PR TITLE
Setup continuous integration for api

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,8 @@ on:
     branches: [master]
 
 jobs:
-  build:
-    name: Build
+  api:
+    name: Integrate api
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -16,7 +16,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
-      - name: Install Dependencies
+      - name: Install dependencies
         run: npm install
-      - name: Compile TypeScript
+      - name: Compile project
         run: npm run build
+      - name: Run tests
+        run: npm run test
+      - name: Check formatting
+        run: npm run format:check
+      - name: Check linting
+        run: npm run lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,8 @@ jobs:
         working-directory: ./api
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+      # TODO cache the following step if it gets too slow
       - name: Install dependencies
         run: npm install
       - name: Compile project
@@ -26,3 +27,15 @@ jobs:
         run: npm run format:check
       - name: Check linting
         run: npm run lint
+
+  www:
+    name: Integrate www
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./www
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: TODO add more steps
+        run: echo 'Hello World!'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,5 +16,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
+      - name: Install Dependencies
+        run: npm install
       - name: Compile TypeScript
         run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: TODO
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v1
+      - name: TODO
+        run: ls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: TODO
+name: Continuous Integration
 
 on:
   push:
@@ -8,10 +8,13 @@ on:
 
 jobs:
   build:
-    name: build
+    name: Build
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./api
     steps:
-      - name: checkout code
+      - name: Checkout code
         uses: actions/checkout@v1
-      - name: TODO
-        run: ls
+      - name: Compile TypeScript
+        run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,6 @@ jobs:
         run: npm run build
       - name: Run tests
         run: npm run test
-      - name: Check formatting
-        run: npm run format:check
       - name: Check linting
         run: npm run lint
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,12 @@ jobs:
       # TODO cache the following step if it gets too slow
       - name: Install dependencies
         run: npm install
+      - name: Check linting
+        run: npm run lint
       - name: Compile project
         run: npm run build
       - name: Run tests
         run: npm run test
-      - name: Check linting
-        run: npm run lint
 
   www:
     name: Integrate www

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,3 @@
+# CompE+ api
+
+TODO there should be an api specific README

--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "format": "prettier --config ../.prettierrc --ignore-path .prettierignore --write .",
-    "lint": "eslint src --ext .js,.ts"
+    "format:check": "prettier --config ../.prettierrc --ignore-path .prettierignore --check .",
+    "lint": "eslint src --ext .js,.ts --max-warnings 0"
   },
   "author": "",
   "license": "ISC",

--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,6 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "format": "prettier --config ../.prettierrc --ignore-path .prettierignore --write .",
-    "format:check": "prettier --config ../.prettierrc --ignore-path .prettierignore --check .",
     "lint": "eslint src --ext .js,.ts --max-warnings 0"
   },
   "author": "",

--- a/api/src/controllers/sample.ts
+++ b/api/src/controllers/sample.ts
@@ -1,9 +1,9 @@
-import { Request, Response, NextFunction } from 'express';
+import { Request, Response } from 'express';
 import logging from '../util/logging';
 
 const NAMESPACE = 'Sample Controller';
 
-const sampleHealthCheck = (req: Request, res: Response, next: NextFunction) => {
+const sampleHealthCheck = (req: Request, res: Response): Response => {
   logging.info(NAMESPACE, 'Sample health check route called.');
 
   return res.status(200).json({ message: 'pong' });

--- a/api/src/routes/middleware.test.ts
+++ b/api/src/routes/middleware.test.ts
@@ -3,32 +3,19 @@ import { NextFunction, Request, Response } from 'express';
 import logging from '../util/logging';
 
 describe('notFound middleware', () => {
-  let mockRequest: Partial<Request>;
-  let mockResponse: Partial<Response>;
-  let nextFunction: NextFunction;
-
-  beforeEach(() => {
-    mockRequest = {};
-    mockResponse = {};
-    mockResponse.json = jest.fn().mockReturnValue(mockResponse);
-    mockResponse.status = jest.fn().mockReturnValue(mockResponse);
-    nextFunction = jest.fn();
-  });
+  const mockRequest: Partial<Request> = {};
+  const mockResponse: Partial<Response> = {};
+  mockResponse.json = jest.fn().mockReturnValue(mockResponse);
+  mockResponse.status = jest.fn().mockReturnValue(mockResponse);
 
   it('always returns 404', () => {
     const expectedResponse = {
       message: 'not found',
     };
-    middleware.notFound(mockRequest as Request, mockResponse as Response, nextFunction);
+    middleware.notFound(mockRequest as Request, mockResponse as Response);
 
     expect(mockResponse.json).toBeCalledWith(expectedResponse);
     expect(mockResponse.status).toBeCalledWith(404);
-  });
-
-  it('does not call further middleware', () => {
-    middleware.notFound(mockRequest as Request, mockResponse as Response, nextFunction);
-
-    expect(nextFunction).toBeCalledTimes(0);
   });
 });
 

--- a/api/src/routes/middleware.ts
+++ b/api/src/routes/middleware.ts
@@ -28,7 +28,7 @@ function logRequest(req: Request, res: Response, next: NextFunction): void {
  * @param next Next function in chain of handlers.
  * @returns
  */
-function notFound(req: Request, res: Response, next: NextFunction): void {
+function notFound(req: Request, res: Response): void {
   const error = new Error('not found');
 
   res.status(404).json({ message: error.message });

--- a/api/src/util/logging.ts
+++ b/api/src/util/logging.ts
@@ -17,7 +17,7 @@ function getTimestamp(): string {
  * @param message Message to log.
  * @param object Optional object to add to log.
  */
-function log(level: string, namespace: string, message: string, object?: any) {
+function log(level: string, namespace: string, message: string, object?: unknown) {
   if (object) {
     console.log(`[${getTimestamp()}] [${level}] [${namespace}] ${message}`, object);
   } else {
@@ -31,7 +31,7 @@ function log(level: string, namespace: string, message: string, object?: any) {
  * @param message Message to log.
  * @param object Optional object to add to log.
  */
-function info(namespace: string, message: string, object?: any) {
+function info(namespace: string, message: string, object?: unknown): void {
   log('INFO', namespace, message, object);
 }
 
@@ -41,7 +41,7 @@ function info(namespace: string, message: string, object?: any) {
  * @param message Message to log.
  * @param object Optional object to add to log.
  */
-function warn(namespace: string, message: string, object?: any) {
+function warn(namespace: string, message: string, object?: unknown): void {
   log('WARN', namespace, message, object);
 }
 
@@ -51,7 +51,7 @@ function warn(namespace: string, message: string, object?: any) {
  * @param message Message to log.
  * @param object Optional object to add to log.
  */
-function error(namespace: string, message: string, object?: any) {
+function error(namespace: string, message: string, object?: unknown): void {
   log('ERROR', namespace, message, object);
 }
 
@@ -61,7 +61,7 @@ function error(namespace: string, message: string, object?: any) {
  * @param message Message to log.
  * @param object Optional object to add to log.
  */
-function debug(namespace: string, message: string, object?: any) {
+function debug(namespace: string, message: string, object?: unknown): void {
   log('DEBUG', namespace, message, object);
 }
 

--- a/www/README.md
+++ b/www/README.md
@@ -1,0 +1,3 @@
+# CompE+ www
+
+TODO there should be a www specific README


### PR DESCRIPTION
## Changes
- Setup continuous integration for `api`.
- Disallow lint warnings... Too strict? I kind of like the strictness to keep our codebase squeaky clean.
- Fix warnings and modify tests as needed

## TODO
- Setup continuous integration for `www`.
- Cache `npm i` in actions

Tickets have been added

Closes #13 