### PR TITLE
Sort imports for API

### DIFF
--- a/api/.eslintrc.js
+++ b/api/.eslintrc.js
@@ -1,9 +1,11 @@
 module.exports = {
     root: true,
     parser: '@typescript-eslint/parser',
-    plugins: ['@typescript-eslint', 'prettier'],
+    plugins: ['@typescript-eslint', 'prettier', 'simple-import-sort'],
     extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
     rules: {
         'prettier/prettier': 'error',
+        'simple-import-sort/imports': 'error',
+        'simple-import-sort/exports': 'error',
     },
 };

--- a/api/README.md
+++ b/api/README.md
@@ -70,6 +70,10 @@ Formats all of the source code.
 
 Runs ESLint across the codebase. Does not tolerate linter warnings.
 
+### `npm run lint:fix`
+
+Runs ESLint across the codebase and fixes errors.
+
 ### `npm run psql`
 
 Shorthand to access local dev database.

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -27,6 +27,7 @@
                 "@typescript-eslint/parser": "^4.24.0",
                 "eslint": "^7.27.0",
                 "eslint-plugin-prettier": "^3.4.0",
+                "eslint-plugin-simple-import-sort": "^7.0.0",
                 "jest": "^26.6.3",
                 "nodemon": "^2.0.7",
                 "pino-pretty": "^5.0.0",
@@ -3139,6 +3140,15 @@
                 "eslint-config-prettier": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/eslint-plugin-simple-import-sort": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+            "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+            "dev": true,
+            "peerDependencies": {
+                "eslint": ">=5.0.0"
             }
         },
         "node_modules/eslint-scope": {
@@ -11522,6 +11532,13 @@
             "requires": {
                 "prettier-linter-helpers": "^1.0.0"
             }
+        },
+        "eslint-plugin-simple-import-sort": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+            "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+            "dev": true,
+            "requires": {}
         },
         "eslint-scope": {
             "version": "5.1.1",

--- a/api/package.json
+++ b/api/package.json
@@ -30,6 +30,7 @@
         "@typescript-eslint/parser": "^4.24.0",
         "eslint": "^7.27.0",
         "eslint-plugin-prettier": "^3.4.0",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
         "jest": "^26.6.3",
         "nodemon": "^2.0.7",
         "pino-pretty": "^5.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -14,6 +14,7 @@
         "test:watch": "jest --watch",
         "format": "prettier --config ../.prettierrc --ignore-path .prettierignore --write .",
         "lint": "eslint src --ext .js,.ts --max-warnings 0",
+        "lint:fix": "eslint src --ext .js,.ts --max-warnings 0 --fix",
         "psql": "PGPASSWORD=postgres psql -h localhost -U postgres -d compe-plus"
     },
     "author": "",

--- a/api/src/controllers/sample.ts
+++ b/api/src/controllers/sample.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
-import pool from '../util/pool';
 import * as db from 'zapatos/db';
+
+import pool from '../util/pool';
 
 /**
  * Sample controller.

--- a/api/src/routes/middleware.test.ts
+++ b/api/src/routes/middleware.test.ts
@@ -1,6 +1,7 @@
-import middleware from './middleware';
 import { NextFunction, Request, Response } from 'express';
+
 import logger from '../util/logger';
+import middleware from './middleware';
 
 describe('notFound middleware', () => {
     const mockRequest: Partial<Request> = {};

--- a/api/src/routes/middleware.ts
+++ b/api/src/routes/middleware.ts
@@ -1,7 +1,8 @@
 import { NextFunction, Request, Response } from 'express';
 import pinoExpressMiddleware from 'express-pino-logger';
-import logger, { standardSerializers, verboseSerializers } from '../util/logger';
+
 import config from '../util/config';
+import logger, { standardSerializers, verboseSerializers } from '../util/logger';
 
 type Middleware = (req: Request, res: Response, next?: NextFunction) => void;
 

--- a/api/src/routes/sample.ts
+++ b/api/src/routes/sample.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+
 import controller from '../controllers/sample';
 
 const router = express.Router();

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,9 +1,10 @@
-import http from 'http';
 import express from 'express';
-import logger from './util/logger';
-import config from './util/config';
-import sampleRoutes from './routes/sample';
+import http from 'http';
+
 import middleware from './routes/middleware';
+import sampleRoutes from './routes/sample';
+import config from './util/config';
+import logger from './util/logger';
 
 const router = express();
 

--- a/api/src/util/logger.ts
+++ b/api/src/util/logger.ts
@@ -1,5 +1,6 @@
-import config from './config';
 import pino from 'pino';
+
+import config from './config';
 
 /**
  * Global logger object.

--- a/api/src/util/pool.ts
+++ b/api/src/util/pool.ts
@@ -1,6 +1,7 @@
+import pg from 'pg';
+
 import config from './config';
 import logger from './logger';
-import pg from 'pg';
 
 /**
  * Pool of Postgres connections to avoid overhead of connecting on every request.


### PR DESCRIPTION
# Overview

Setup linting to sort imports for API. I'm tired of dealing with this myself.

# Changes

- Add plugin to ESLint to sort imports
- Add script to run ESLint fixes

# Questions & Notes

- Should we use same plugin in www?