### PR TITLE
Mobile view for static

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -23,6 +23,7 @@
                 "@types/redux": "^3.6.0",
                 "axios": "^0.21.1",
                 "react": "^17.0.2",
+                "react-device-detect": "^1.17.0",
                 "react-dom": "^17.0.2",
                 "react-redux": "^7.2.4",
                 "react-router-dom": "^5.2.0",
@@ -15404,6 +15405,18 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/react-device-detect": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.17.0.tgz",
+            "integrity": "sha512-bBblIStwpHmoS281JFIVqeimcN3LhpoP5YKDWzxQdBIUP8S2xPvHDgizLDhUq2ScguLfVPmwfF5y268EEQR60w==",
+            "dependencies": {
+                "ua-parser-js": "^0.7.24"
+            },
+            "peerDependencies": {
+                "react": ">= 0.14.0 < 18.0.0",
+                "react-dom": ">= 0.14.0 < 18.0.0"
+            }
+        },
         "node_modules/react-dom": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -18132,6 +18145,24 @@
             },
             "engines": {
                 "node": ">=4.2.0"
+            }
+        },
+        "node_modules/ua-parser-js": {
+            "version": "0.7.28",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+            "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/ua-parser-js"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/faisalman"
+                }
+            ],
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/unbox-primitive": {
@@ -33151,6 +33182,14 @@
                 }
             }
         },
+        "react-device-detect": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.17.0.tgz",
+            "integrity": "sha512-bBblIStwpHmoS281JFIVqeimcN3LhpoP5YKDWzxQdBIUP8S2xPvHDgizLDhUq2ScguLfVPmwfF5y268EEQR60w==",
+            "requires": {
+                "ua-parser-js": "^0.7.24"
+            }
+        },
         "react-dom": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -35452,6 +35491,11 @@
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
             "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg=="
+        },
+        "ua-parser-js": {
+            "version": "0.7.28",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+            "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
         },
         "unbox-primitive": {
             "version": "1.0.1",

--- a/www/package.json
+++ b/www/package.json
@@ -19,6 +19,7 @@
         "@types/redux": "^3.6.0",
         "axios": "^0.21.1",
         "react": "^17.0.2",
+        "react-device-detect": "^1.17.0",
         "react-dom": "^17.0.2",
         "react-redux": "^7.2.4",
         "react-router-dom": "^5.2.0",

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -16,7 +16,10 @@ import Community from './routes/Community';
 import theme from './styles/theme';
 
 // Constants
-import { COMMUNITY, COMMUNITY_ROUTE, COMPE_CLUB, COMPE_CLUB_ROUTE, COMPE_PLUS, MOCK_INTERVIEW, MOCK_INTERVIEW_ROUTE, RESUME_REVIEW, RESUME_REVIEW_ROUTE } from './util/constants';
+import { COMPE_PLUS } from './util/constants';
+
+import { BrowserView, MobileView } from 'react-device-detect';
+import MobileLanding from './routes/MobileLanding';
 
 const header_sections: Section[] = [
     // { title: RESUME_REVIEW, url: RESUME_REVIEW_ROUTE },
@@ -30,22 +33,27 @@ const App: FC = () => {
             <CssBaseline />
             <Container maxWidth={false} style={{ padding: 0 }}>
                 <Header sections={header_sections} title={COMPE_PLUS} />
-                <Router>
-                    <Switch>
-                        <Route path='/resume-review'>
-                            <ResumeReview />
-                        </Route>
-                        <Route path='/mock-interview'>
-                            <MockInterview />
-                        </Route>
-                        <Route path='/community'>
-                            <Community />
-                        </Route>
-                        <Route path='/'>
-                            <Landing />
-                        </Route>
-                    </Switch>
-                </Router>
+                <BrowserView>
+                    <Router>
+                        <Switch>
+                            <Route path='/resume-review'>
+                                <ResumeReview />
+                            </Route>
+                            <Route path='/mock-interview'>
+                                <MockInterview />
+                            </Route>
+                            <Route path='/community'>
+                                <Community />
+                            </Route>
+                            <Route path='/'>
+                                <Landing />
+                            </Route>
+                        </Switch>
+                    </Router>
+                </BrowserView>
+                <MobileView>
+                    <MobileLanding />
+                </MobileView>
             </Container>
         </ThemeProvider>
     );

--- a/www/src/routes/MobileLanding.tsx
+++ b/www/src/routes/MobileLanding.tsx
@@ -1,7 +1,9 @@
-import { Grid, Typography, makeStyles } from '@material-ui/core';
+import { Grid, Typography, makeStyles, Button, InputBase, Paper } from '@material-ui/core';
 import React, { FC } from 'react';
 import BlackLogo from '../assets/logo_black.svg';
 import Wave1 from '../assets/wave_1.svg';
+import LightGreenLogo from '../assets/logo_light_green.svg';
+import Wave4 from '../assets/wave_4.svg';
 
 const MobileLanding: FC = () => {
     const classes = useStyles();
@@ -24,6 +26,38 @@ const MobileLanding: FC = () => {
                 </Grid>
             </Grid>
             <img src={Wave1} className={classes.wave} />
+            <Grid container item justify='center' style={{ minHeight: '50vh' }}>
+                <Grid container item justify='center' xs={10} spacing={2}>
+                    <Grid container item alignItems='center' justify='center' spacing={2}>
+                        <Grid item>
+                            <Typography variant='h1'>Mailing List</Typography>
+                        </Grid>
+                        <Grid item>
+                            <Typography align='center' variant='body1' style={{ fontWeight: 200 }}>
+                                For updates on CompE+ or if you would like to volunteer to review resumes or hold mock interviews, sign up for our mailing list:
+                            </Typography>
+                        </Grid>
+                    </Grid>
+                    <Grid container item alignItems='center' justify='center' direction='column' spacing={2}>
+                        <Grid container item alignItems='center' justify='center'>
+                            <Paper component='form' className={classes.text_input_root}>
+                                <InputBase className={classes.text_input} placeholder='Email Address' />
+                            </Paper>
+                        </Grid>
+                        <Grid container item alignItems='center' justify='center'>
+                            <Button variant='contained' className={classes.main_button}>
+                                Submit
+                            </Button>
+                        </Grid>
+                    </Grid>
+                </Grid>
+            </Grid>
+            <img src={Wave4} className={classes.wave} />
+            <Grid container item className={classes.footer}>
+                <Grid container item className={classes.wave_pattern} justify='center' direction='column' alignItems='center'>
+                    <img src={LightGreenLogo} className={classes.footer_logo} />
+                </Grid>
+            </Grid>
         </>
     );
 };
@@ -39,6 +73,44 @@ const useStyles = makeStyles((theme) => ({
     logo_1: {
         width: '50%',
         height: 'auto',
+    },
+    text_input_root: {
+        padding: '2px 4px',
+        display: 'flex',
+        alignItems: 'center',
+        width: 400,
+        borderRadius: 0,
+    },
+    text_input: {
+        marginLeft: theme.spacing(1),
+        flex: 1,
+    },
+    text_input_icon_button: {
+        padding: 10,
+    },
+    text_input_divider: {
+        height: 28,
+        margin: 4,
+    },
+    main_button: {
+        backgroundColor: theme.palette.primary.dark,
+        outlineColor: theme.palette.primary.dark,
+        color: theme.palette.primary.light,
+        fontWeight: 500,
+        borderRadius: 0,
+        '&:hover': {
+            backgroundColor: theme.palette.primary.light,
+            color: theme.palette.primary.dark,
+        },
+    },
+    footer: {
+        padding: '0',
+        marginTop: '-1vh',
+    },
+    footer_logo: {
+        width: '10%',
+        height: 'auto',
+        margin: '1em',
     },
 }));
 export default MobileLanding;

--- a/www/src/routes/MobileLanding.tsx
+++ b/www/src/routes/MobileLanding.tsx
@@ -1,0 +1,44 @@
+import { Grid, Typography, makeStyles } from '@material-ui/core';
+import React, { FC } from 'react';
+import BlackLogo from '../assets/logo_black.svg';
+import Wave1 from '../assets/wave_1.svg';
+
+const MobileLanding: FC = () => {
+    const classes = useStyles();
+    return (
+        <>
+            <Grid container item className={classes.wave_pattern} justify='center' style={{ minHeight: '50vh', paddingTop: '10vh' }} id='intro'>
+                <Grid container item justify='center' spacing={5}>
+                    <Grid container item xs={10} alignItems='center' justify='center' spacing={3}>
+                        <Grid container item justify='center'>
+                            <img src={BlackLogo} className={classes.logo_1} />
+                            <Typography variant='h1'>CompE+</Typography>
+                        </Grid>
+                        <Grid item>
+                            <Typography align='center' variant='body1' style={{ fontWeight: 200 }}>
+                                The developers are working very hard to build CompE+ with limited time so some funtionality had to be deferred. <br />
+                                As such, this site is not optimized for mobile 😞 please open compe.plus on desktop
+                            </Typography>
+                        </Grid>
+                    </Grid>
+                </Grid>
+            </Grid>
+            <img src={Wave1} className={classes.wave} />
+        </>
+    );
+};
+
+const useStyles = makeStyles((theme) => ({
+    wave_pattern: {
+        backgroundColor: theme.palette.primary.main,
+    },
+    wave: {
+        width: '100%',
+        height: 'auto',
+    },
+    logo_1: {
+        width: '50%',
+        height: 'auto',
+    },
+}));
+export default MobileLanding;

--- a/www/src/routes/MobileLanding.tsx
+++ b/www/src/routes/MobileLanding.tsx
@@ -16,7 +16,7 @@ const MobileLanding: FC = () => {
                         </Grid>
                         <Grid item>
                             <Typography align='center' variant='body1' style={{ fontWeight: 200 }}>
-                                The developers are working very hard to build CompE+ with limited time so some funtionality had to be deferred. <br />
+                                The developers are working very hard to build CompE+ with limited time so some functionality had to be deferred. <br />
                                 As such, this site is not optimized for mobile 😞 please open compe.plus on desktop
                             </Typography>
                         </Grid>


### PR DESCRIPTION
# Overview

Create mobile version of static site.

I wanted to keep this version as simple as possible to avoid further dev work on just layout / making it responsive. So this will be a temporary solution for users going to the site on mobile. I think when this is fully deployed, I'd want to essentially render a mobile-friendly version of our static site if a user opens it on their phone. This way, they can still get information about the program but they'd still need to go on their desktop to login and make use of the services. 

Wait until #68 is merged 

# Changes

- Imported react-device-detect to detect if the app is open on a mobile device 
- Added MobileLanding route 

# Issue tracking

Closes #122 

# Testing & Demo
To test locally (I just found this out lmao), find your IPv4 address then open your browser on your phone and enter "IP_ADDRESS:3000" with your localhost running on your computer.

![image](https://user-images.githubusercontent.com/32345990/122865821-3ba55700-d2e4-11eb-986a-84c2d1ee44ac.png)
![image](https://user-images.githubusercontent.com/32345990/123119202-8b794080-d400-11eb-8256-54dfad3db8e9.png)

