### PR TITLE
Move enzyme boilerplate to `setupTests.ts`

### DIFF
--- a/www/src/routes/Landing.test.tsx
+++ b/www/src/routes/Landing.test.tsx
@@ -1,11 +1,9 @@
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import Enzyme, { shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import { shallowWithAuth0 } from '../util/testWithAuth0';
 import Landing, { Intro } from './Landing';
 
-Enzyme.configure({ adapter: new Adapter() });
 describe('Landing', () => {
     it('renders correctly', () => {
         const wrapper = shallow(<Landing />);

--- a/www/src/setupTests.ts
+++ b/www/src/setupTests.ts
@@ -1,7 +1,3 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';

--- a/www/src/setupTests.ts
+++ b/www/src/setupTests.ts
@@ -3,3 +3,8 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import Enzyme from 'enzyme';
+
+Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
# Overview

* Individual tests no longer need to set-up enzyme per test file

# Changes

* Move Enzyme configuration to `setupTests`

# Questions & Notes

# Issue tracking

Closes #131 

# Testing & Demo

Running `npm test` in `www` should not yield any errors