### PR TITLE
Improve authentication middleware

### DIFF
--- a/api/src/controllers/middleware.test.ts
+++ b/api/src/controllers/middleware.test.ts
@@ -98,6 +98,14 @@ describe('errorHandler middleware', () => {
         expect(resStatus).toBeCalledWith(404);
     });
 
+    it('handles authentication errors', () => {
+        const e = new Error('asdf');
+        e.name = 'UnauthorizedError';
+        middleware.errorHandler()(e, mockRequest as Request, mockResponse as Response, nextFunction);
+        expect(resJson).toBeCalledWith({ code: 401, message: 'Not authenticated' });
+        expect(resStatus).toBeCalledWith(401);
+    });
+
     // Can't figure out how to mock req.log.error so I'm punting on this
     it.todo('handles unknown errors');
 });

--- a/api/src/controllers/middleware.test.ts
+++ b/api/src/controllers/middleware.test.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
+import { UnauthorizedError } from 'express-jwt';
 
 import NotFoundException from '../exceptions/NotFoundException';
 import * as checkJwt from '../util/checkJwt';
@@ -99,8 +100,7 @@ describe('errorHandler middleware', () => {
     });
 
     it('handles authentication errors', () => {
-        const e = new Error('asdf');
-        e.name = 'UnauthorizedError';
+        const e = new UnauthorizedError('credentials_required', { message: '' });
         middleware.errorHandler()(e, mockRequest as Request, mockResponse as Response, nextFunction);
         expect(resJson).toBeCalledWith({ code: 401, message: 'Not authenticated' });
         expect(resStatus).toBeCalledWith(401);

--- a/api/src/controllers/middleware.ts
+++ b/api/src/controllers/middleware.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from 'express';
 import pinoExpressMiddleware from 'express-pino-logger';
 
 import HttpException from '../exceptions/HttpException';
+import NotAuthenticatedException from '../exceptions/NotAuthenticatedException';
 import NotFoundException from '../exceptions/NotFoundException';
 import { checkJwt } from '../util/checkJwt';
 import config from '../util/config';
@@ -40,6 +41,8 @@ function errorHandler(): ErrMiddleware {
         if (err instanceof HttpException) {
             // Handle a known server error
             outErr = err;
+        } else if (err.name === 'UnauthorizedError') {
+            outErr = new NotAuthenticatedException();
         } else {
             // Handle an unknown error
             req.log.error({ error: err }, 'Unknown error');

--- a/api/src/controllers/middleware.ts
+++ b/api/src/controllers/middleware.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
+import { UnauthorizedError } from 'express-jwt';
 import pinoExpressMiddleware from 'express-pino-logger';
 
 import HttpException from '../exceptions/HttpException';
@@ -41,7 +42,7 @@ function errorHandler(): ErrMiddleware {
         if (err instanceof HttpException) {
             // Handle a known server error
             outErr = err;
-        } else if (err.name === 'UnauthorizedError') {
+        } else if (err instanceof UnauthorizedError) {
             outErr = new NotAuthenticatedException();
         } else {
             // Handle an unknown error

--- a/api/src/exceptions/NotAuthenticatedException.ts
+++ b/api/src/exceptions/NotAuthenticatedException.ts
@@ -1,0 +1,16 @@
+import HttpException from './HttpException';
+
+/**
+ * Not authenticated exception.
+ */
+class NotAuthenticatedException extends HttpException {
+    /**
+     * Create an NotAuthenticatedException.
+     */
+    constructor() {
+        super(401, 'Not authenticated');
+        Object.setPrototypeOf(this, NotAuthenticatedException.prototype);
+    }
+}
+
+export default NotAuthenticatedException;

--- a/api/src/exceptions/exception.test.ts
+++ b/api/src/exceptions/exception.test.ts
@@ -1,4 +1,5 @@
 import HttpException from './HttpException';
+import NotAuthenticatedException from './NotAuthenticatedException';
 import NotFoundException from './NotFoundException';
 import NotImplementedException from './NotImplementedException';
 import ValidationException from './ValidationException';
@@ -59,6 +60,17 @@ describe('ValidationException', () => {
         expect(obj.code).toEqual(400);
         expect(obj.message).toEqual('Invalid body');
         expect(obj.details).toMatchObject({ fieldA: 'Is too long' });
+    });
+});
+
+describe('NotAuthenticatedException', () => {
+    it('serializes properly', () => {
+        const e = new NotAuthenticatedException();
+        const obj = e.serialize();
+
+        expect(obj.code).toEqual(401);
+        expect(obj.message).toEqual('Not authenticated');
+        expect(obj.details).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
# Overview

Improve authentication middleware.

# Changes

- Catch error thrown by `checkJwt` when a request is not authenticated
- Add a new `NotAuthenticatedException`

# Questions & Notes

N/A

# Issue tracking

Next PR will add authentication 

# Testing & Demo

See unit tests
