### PR TITLE
Update fluent validation library

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,7 +15,7 @@
                 "express-jwt": "^6.0.0",
                 "express-jwt-authz": "^2.4.1",
                 "express-pino-logger": "^6.0.0",
-                "fluentvalidation-ts": "^2.2.1",
+                "fluentvalidation-ts": "^2.2.2",
                 "jwks-rsa": "^2.0.3",
                 "pg": "^8.6.0",
                 "pino": "^6.11.3",
@@ -3915,9 +3915,9 @@
             "dev": true
         },
         "node_modules/fluentvalidation-ts": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/fluentvalidation-ts/-/fluentvalidation-ts-2.2.1.tgz",
-            "integrity": "sha512-cdf4ZcilVfyuDQC/mw1MEL+sc9OPlWtZuH9Vb113E+dISR9X1kGBc7AkLMt3ocUlynsEQZGEkFy7T8JlY8EJ0A=="
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/fluentvalidation-ts/-/fluentvalidation-ts-2.2.2.tgz",
+            "integrity": "sha512-ZVBNfYtmfGu+hFIvtL1s+J+pVhP61XoFJihs/I4Ld3NYECqpbYUbZCWIIFNbFEL37wha9/odRCN+MvgBOJwysQ=="
         },
         "node_modules/follow-redirects": {
             "version": "1.14.1",
@@ -12467,9 +12467,9 @@
             "dev": true
         },
         "fluentvalidation-ts": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/fluentvalidation-ts/-/fluentvalidation-ts-2.2.1.tgz",
-            "integrity": "sha512-cdf4ZcilVfyuDQC/mw1MEL+sc9OPlWtZuH9Vb113E+dISR9X1kGBc7AkLMt3ocUlynsEQZGEkFy7T8JlY8EJ0A=="
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/fluentvalidation-ts/-/fluentvalidation-ts-2.2.2.tgz",
+            "integrity": "sha512-ZVBNfYtmfGu+hFIvtL1s+J+pVhP61XoFJihs/I4Ld3NYECqpbYUbZCWIIFNbFEL37wha9/odRCN+MvgBOJwysQ=="
         },
         "follow-redirects": {
             "version": "1.14.1",

--- a/api/package.json
+++ b/api/package.json
@@ -51,7 +51,7 @@
         "express-jwt": "^6.0.0",
         "express-jwt-authz": "^2.4.1",
         "express-pino-logger": "^6.0.0",
-        "fluentvalidation-ts": "^2.2.1",
+        "fluentvalidation-ts": "^2.2.2",
         "jwks-rsa": "^2.0.3",
         "pg": "^8.6.0",
         "pino": "^6.11.3",

--- a/api/src/controllers/resumeReview/postResumeReview.ts
+++ b/api/src/controllers/resumeReview/postResumeReview.ts
@@ -15,7 +15,7 @@ class ReqBodyValidator extends Validator<ReqBody> {
     constructor() {
         super('message body');
 
-        this.ruleFor('reviewee').mustAsync([beAValidUuid, beAValidUser]);
+        this.ruleFor('reviewee').mustAsync(beAValidUuid).mustAsync(beAValidUser);
     }
 }
 


### PR DESCRIPTION
# Overview

Update fluent validation library. There was a bug in the library that prevented chaining `mustAsync` method calls. I opened an [issue](https://github.com/AlexJPotter/fluentvalidation-ts/issues/18) and the maintainer fixed it :smile:.
