### PR TITLE
Patch document

### DIFF
--- a/api/src/controllers/document/index.ts
+++ b/api/src/controllers/document/index.ts
@@ -1,1 +1,2 @@
+export { default as patchAllDocument } from './patchAllDocument';
 export { default as postDocument } from './postDocument';

--- a/api/src/controllers/document/index.ts
+++ b/api/src/controllers/document/index.ts
@@ -1,2 +1,3 @@
 export { default as patchAllDocument } from './patchAllDocument';
+export { default as patchMyDocument } from './patchMyDocument';
 export { default as postDocument } from './postDocument';

--- a/api/src/controllers/document/patchAllDocument.test.ts
+++ b/api/src/controllers/document/patchAllDocument.test.ts
@@ -1,0 +1,151 @@
+import { NextFunction, Request, Response } from 'express';
+import { mocked } from 'ts-jest/utils';
+
+import InternalServerErrorException from '../../exceptions/InternalServerErrorException';
+import * as documentRepository from '../../repositories/documentRepository';
+import * as resumeReviewRepository from '../../repositories/resumeReviewRepository';
+import * as s3Repository from '../../repositories/s3Repository';
+import testConstants from '../../util/testConstants';
+import patchAllDocument from './patchAllDocument';
+
+jest.mock('../../repositories/documentRepository');
+const mockDocumentRepository = mocked(documentRepository, true);
+
+jest.mock('../../repositories/s3Repository');
+const mockS3Repository = mocked(s3Repository, true);
+
+jest.mock('../../repositories/resumeReviewRepository');
+const mockResumeReviewRepository = mocked(resumeReviewRepository, true);
+
+type Params = {
+    resumeReview: string;
+    document: string;
+};
+
+let req: Partial<Request>;
+let res: Partial<Response>;
+let next: jest.MockedFunction<NextFunction>;
+
+beforeEach(() => {
+    req = {
+        body: {
+            note: 'my note',
+            base64Contents: Buffer.from('My file contents').toString('base64'),
+        },
+        params: {
+            resumeReview: testConstants.resumeReview1.id,
+            document: testConstants.document1.id,
+        },
+    };
+    res = { status: jest.fn().mockReturnThis(), json: jest.fn().mockReturnThis() };
+    next = jest.fn();
+    mockResumeReviewRepository.get.mockResolvedValueOnce([testConstants.resumeReview1]);
+    mockDocumentRepository.get.mockResolvedValueOnce([testConstants.document1]);
+});
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+it('rejects non-uuid resume review', async () => {
+    req.params = { resumeReview: 'lolz', document: 'a41dbb6d-8957-4d67-a13c-05986cb01916' };
+
+    await patchAllDocument(req as Request<Params>, res as Response, next);
+
+    expect(next.mock.calls[0][0]).toMatchObject({ message: 'Invalid route parameters', status: 400, details: { resumeReview: 'Must be a UUID' } });
+});
+
+it('rejects non-uuid document', async () => {
+    req.params = { resumeReview: '52c2cbdc-e0a8-48e7-9302-92a37e016ab0', document: 'lolz' };
+
+    await patchAllDocument(req as Request<Params>, res as Response, next);
+
+    expect(next.mock.calls[0][0]).toMatchObject({ message: 'Invalid route parameters', status: 400, details: { document: 'Must be a UUID' } });
+});
+
+it('rejects non-exsistent resume review', async () => {
+    mockResumeReviewRepository.get.mockReset();
+    mockResumeReviewRepository.get.mockResolvedValueOnce([]);
+    await patchAllDocument(req as Request<Params>, res as Response, next);
+
+    expect(next.mock.calls[0][0]).toMatchObject({ message: 'Invalid route parameters', status: 400, details: { resumeReview: 'Must be a resume review that already exists' } });
+});
+
+it('rejects non-exsistent document', async () => {
+    mockDocumentRepository.get.mockReset();
+    mockDocumentRepository.get.mockResolvedValueOnce([]);
+    await patchAllDocument(req as Request<Params>, res as Response, next);
+
+    expect(next.mock.calls[0][0]).toMatchObject({ message: 'Invalid route parameters', status: 400, details: { document: 'Must be a document that already exists' } });
+});
+
+it('rejects invalid base64Contents', async () => {
+    req.body.base64Contents = '&&';
+
+    await patchAllDocument(req as Request<Params>, res as Response, next);
+
+    expect(next.mock.calls[0][0]).toMatchObject({ message: 'Invalid message body', status: 400, details: { base64Contents: 'Must be properly base64 encoded' } });
+});
+
+it('works with both fields as null', async () => {
+    req.body = {};
+
+    await patchAllDocument(req as Request<Params>, res as Response, next);
+
+    expect(res.status).toBeCalledWith(204);
+    expect(documentRepository.update).not.toBeCalled();
+    expect(s3Repository.upload).not.toBeCalled();
+});
+
+it('works with just note field', async () => {
+    req.body = { note: 'new note' };
+
+    await patchAllDocument(req as Request<Params>, res as Response, next);
+
+    expect(res.status).toBeCalledWith(204);
+    expect(documentRepository.update).toBeCalledWith(testConstants.document1.id, 'new note');
+    expect(s3Repository.upload).not.toBeCalled();
+});
+
+it('works with just base64Contents field', async () => {
+    const contents = Buffer.from('My file contents').toString('base64');
+    req.body = { base64Contents: contents };
+
+    await patchAllDocument(req as Request<Params>, res as Response, next);
+
+    expect(res.status).toBeCalledWith(204);
+    expect(documentRepository.update).not.toBeCalled();
+    expect(s3Repository.upload).toBeCalledWith(`resume-reviews/${testConstants.resumeReview1.id}/documents/${testConstants.document1.id}`, contents, 'base64');
+});
+
+it('works with both fields', async () => {
+    await patchAllDocument(req as Request<Params>, res as Response, next);
+
+    expect(res.status).toBeCalledWith(204);
+    expect(documentRepository.update).toBeCalledWith(testConstants.document1.id, 'my note');
+    expect(s3Repository.upload).toBeCalledWith(
+        `resume-reviews/${testConstants.resumeReview1.id}/documents/${testConstants.document1.id}`,
+        Buffer.from('My file contents').toString('base64'),
+        'base64',
+    );
+});
+
+it('catches error with note', async () => {
+    const err = new Error('');
+    mockDocumentRepository.update.mockRejectedValueOnce(err);
+
+    await patchAllDocument(req as Request<Params>, res as Response, next);
+
+    expect(res.status).not.toBeCalled();
+    expect(next).toBeCalledWith(new InternalServerErrorException({ issue: 'Failed to update note or base64Contents. Try again with same data.' }, err));
+});
+
+it('catches error with base64Content', async () => {
+    const err = new Error('');
+    mockS3Repository.upload.mockRejectedValueOnce(err);
+
+    await patchAllDocument(req as Request<Params>, res as Response, next);
+
+    expect(res.status).not.toBeCalled();
+    expect(next).toBeCalledWith(new InternalServerErrorException({ issue: 'Failed to update note or base64Contents. Try again with same data.' }, err));
+});

--- a/api/src/controllers/document/patchAllDocument.ts
+++ b/api/src/controllers/document/patchAllDocument.ts
@@ -1,0 +1,67 @@
+import { Request, Response } from 'express';
+import type * as s from 'zapatos/schema';
+
+import InternalServerErrorException from '../../exceptions/InternalServerErrorException';
+import * as documentRepository from '../../repositories/documentRepository';
+import * as s3Repository from '../../repositories/s3Repository';
+import controller from '../controllerUtil';
+import Validator, { beAValidDocument, beAValidResumeReview, beAValidUuid, beProperlyBase64Encoded } from '../validation';
+
+type Params = {
+    resumeReview: string;
+    document: string;
+};
+
+class ParamsValidator extends Validator<Params> {
+    constructor() {
+        super('route parameters');
+
+        this.ruleFor('resumeReview').mustAsync(beAValidUuid).mustAsync(beAValidResumeReview);
+
+        this.ruleFor('document').mustAsync(beAValidUuid).mustAsync(beAValidDocument);
+    }
+}
+
+type ReqBody = {
+    note?: string;
+    base64Contents?: string;
+};
+
+class ReqBodyValidator extends Validator<ReqBody> {
+    constructor() {
+        super('message body');
+
+        this.ruleFor('base64Contents')
+            .mustAsync(beProperlyBase64Encoded)
+            .when((reqBody) => reqBody.base64Contents !== undefined);
+    }
+}
+
+type ResBody = { document: s.documents.JSONSelectable };
+
+/**
+ * Update any document.
+ * @param req HTTP request.
+ * @param res HTTP response.
+ * @returns Nothing.
+ */
+const patchAllDocument = controller(async (req: Request<Params, ResBody, ReqBody>, res: Response<ResBody>): Promise<void> => {
+    await new ParamsValidator().validateAndThrow(req.params);
+    await new ReqBodyValidator().validateAndThrow(req.body);
+
+    try {
+        if (req.body.note !== null && req.body.note !== undefined) {
+            await documentRepository.update(req.params.document, req.body.note);
+        }
+        if (req.body.base64Contents !== null && req.body.base64Contents !== undefined) {
+            const key = `resume-reviews/${req.params.resumeReview}/documents/${req.params.document}`;
+            await s3Repository.upload(key, req.body.base64Contents, 'base64');
+        }
+    } catch (err) {
+        throw new InternalServerErrorException({ issue: 'Failed to update note or base64Contents. Try again with same data.' }, err);
+    }
+
+    res.status(204).end();
+});
+
+export default patchAllDocument;

--- a/api/src/controllers/document/patchMyDocument.test.ts
+++ b/api/src/controllers/document/patchMyDocument.test.ts
@@ -1,0 +1,166 @@
+import { NextFunction, Request, Response } from 'express';
+import { mocked } from 'ts-jest/utils';
+
+import InternalServerErrorException from '../../exceptions/InternalServerErrorException';
+import NotAuthorizedException from '../../exceptions/NotAuthorizedException';
+import * as documentRepository from '../../repositories/documentRepository';
+import * as resumeReviewRepository from '../../repositories/resumeReviewRepository';
+import * as s3Repository from '../../repositories/s3Repository';
+import testConstants from '../../util/testConstants';
+import patchMyDocument from './patchMyDocument';
+
+jest.mock('../../repositories/documentRepository');
+const mockDocumentRepository = mocked(documentRepository, true);
+
+jest.mock('../../repositories/s3Repository');
+const mockS3Repository = mocked(s3Repository, true);
+
+jest.mock('../../repositories/resumeReviewRepository');
+const mockResumeReviewRepository = mocked(resumeReviewRepository, true);
+
+type Params = {
+    resumeReview: string;
+    document: string;
+};
+
+let req: Partial<Request>;
+let res: Partial<Response>;
+let next: jest.MockedFunction<NextFunction>;
+
+beforeEach(() => {
+    req = {
+        body: {
+            note: 'my note',
+            base64Contents: Buffer.from('My file contents').toString('base64'),
+        },
+        params: {
+            resumeReview: testConstants.resumeReview1.id,
+            document: testConstants.document1.id,
+        },
+        user: {
+            sub: testConstants.user1.id,
+        },
+    };
+    res = { status: jest.fn().mockReturnThis(), json: jest.fn().mockReturnThis() };
+    next = jest.fn();
+    mockResumeReviewRepository.get.mockResolvedValueOnce([testConstants.resumeReview1]);
+    mockDocumentRepository.get.mockResolvedValue([testConstants.document1]);
+});
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+it('rejects non-uuid resume review', async () => {
+    req.params = { resumeReview: 'lolz', document: 'a41dbb6d-8957-4d67-a13c-05986cb01916' };
+
+    await patchMyDocument(req as Request<Params>, res as Response, next);
+
+    expect(next.mock.calls[0][0]).toMatchObject({ message: 'Invalid route parameters', status: 400, details: { resumeReview: 'Must be a UUID' } });
+});
+
+it('rejects non-uuid document', async () => {
+    req.params = { resumeReview: '52c2cbdc-e0a8-48e7-9302-92a37e016ab0', document: 'lolz' };
+
+    await patchMyDocument(req as Request<Params>, res as Response, next);
+
+    expect(next.mock.calls[0][0]).toMatchObject({ message: 'Invalid route parameters', status: 400, details: { document: 'Must be a UUID' } });
+});
+
+it('rejects non-exsistent resume review', async () => {
+    mockResumeReviewRepository.get.mockReset();
+    mockResumeReviewRepository.get.mockResolvedValueOnce([]);
+    await patchMyDocument(req as Request<Params>, res as Response, next);
+
+    expect(next.mock.calls[0][0]).toMatchObject({ message: 'Invalid route parameters', status: 400, details: { resumeReview: 'Must be a resume review that already exists' } });
+});
+
+it('rejects non-exsistent document', async () => {
+    mockDocumentRepository.get.mockReset();
+    mockDocumentRepository.get.mockResolvedValueOnce([]);
+    await patchMyDocument(req as Request<Params>, res as Response, next);
+
+    expect(next.mock.calls[0][0]).toMatchObject({ message: 'Invalid route parameters', status: 400, details: { document: 'Must be a document that already exists' } });
+});
+
+it('rejects invalid base64Contents', async () => {
+    req.body.base64Contents = '&&';
+
+    await patchMyDocument(req as Request<Params>, res as Response, next);
+
+    expect(next.mock.calls[0][0]).toMatchObject({ message: 'Invalid message body', status: 400, details: { base64Contents: 'Must be properly base64 encoded' } });
+});
+
+it('works with both fields as null', async () => {
+    req.body = {};
+
+    await patchMyDocument(req as Request<Params>, res as Response, next);
+
+    expect(res.status).toBeCalledWith(204);
+    expect(documentRepository.update).not.toBeCalled();
+    expect(s3Repository.upload).not.toBeCalled();
+});
+
+it('works with just note field', async () => {
+    req.body = { note: 'new note' };
+
+    await patchMyDocument(req as Request<Params>, res as Response, next);
+
+    expect(res.status).toBeCalledWith(204);
+    expect(documentRepository.update).toBeCalledWith(testConstants.document1.id, 'new note');
+    expect(s3Repository.upload).not.toBeCalled();
+});
+
+it('works with just base64Contents field', async () => {
+    const contents = Buffer.from('My file contents').toString('base64');
+    req.body = { base64Contents: contents };
+
+    await patchMyDocument(req as Request<Params>, res as Response, next);
+
+    expect(res.status).toBeCalledWith(204);
+    expect(documentRepository.update).not.toBeCalled();
+    expect(s3Repository.upload).toBeCalledWith(`resume-reviews/${testConstants.resumeReview1.id}/documents/${testConstants.document1.id}`, contents, 'base64');
+});
+
+it('works with both fields', async () => {
+    await patchMyDocument(req as Request<Params>, res as Response, next);
+
+    expect(res.status).toBeCalledWith(204);
+    expect(documentRepository.update).toBeCalledWith(testConstants.document1.id, 'my note');
+    expect(s3Repository.upload).toBeCalledWith(
+        `resume-reviews/${testConstants.resumeReview1.id}/documents/${testConstants.document1.id}`,
+        Buffer.from('My file contents').toString('base64'),
+        'base64',
+    );
+});
+
+it('catches error with note', async () => {
+    const err = new Error('');
+    mockDocumentRepository.update.mockRejectedValueOnce(err);
+
+    await patchMyDocument(req as Request<Params>, res as Response, next);
+
+    expect(res.status).not.toBeCalled();
+    expect(next).toBeCalledWith(new InternalServerErrorException({ issue: 'Failed to update note or base64Contents. Try again with same data.' }, err));
+});
+
+it('catches error with base64Content', async () => {
+    const err = new Error('');
+    mockS3Repository.upload.mockRejectedValueOnce(err);
+
+    await patchMyDocument(req as Request<Params>, res as Response, next);
+
+    expect(res.status).not.toBeCalled();
+    expect(next).toBeCalledWith(new InternalServerErrorException({ issue: 'Failed to update note or base64Contents. Try again with same data.' }, err));
+});
+
+it('will not allow a user to modify a document not related to them', async () => {
+    mockDocumentRepository.get.mockReset();
+    mockDocumentRepository.get.mockResolvedValueOnce([testConstants.document1]);
+    mockDocumentRepository.get.mockResolvedValueOnce([]);
+    await patchMyDocument(req as Request<Params>, res as Response, next);
+
+    expect(documentRepository.update).not.toBeCalled();
+    expect(s3Repository.upload).not.toBeCalled();
+    expect(next).toBeCalledWith(new NotAuthorizedException());
+});

--- a/api/src/controllers/document/patchMyDocument.ts
+++ b/api/src/controllers/document/patchMyDocument.ts
@@ -1,0 +1,73 @@
+import { Request, Response } from 'express';
+import type * as s from 'zapatos/schema';
+
+import InternalServerErrorException from '../../exceptions/InternalServerErrorException';
+import NotAuthorizedException from '../../exceptions/NotAuthorizedException';
+import * as documentRepository from '../../repositories/documentRepository';
+import * as s3Repository from '../../repositories/s3Repository';
+import controller from '../controllerUtil';
+import Validator, { beAValidDocument, beAValidResumeReview, beAValidUuid, beProperlyBase64Encoded } from '../validation';
+
+type Params = {
+    resumeReview: string;
+    document: string;
+};
+
+class ParamsValidator extends Validator<Params> {
+    constructor() {
+        super('route parameters');
+
+        this.ruleFor('resumeReview').mustAsync(beAValidUuid).mustAsync(beAValidResumeReview);
+
+        this.ruleFor('document').mustAsync(beAValidUuid).mustAsync(beAValidDocument);
+    }
+}
+
+type ReqBody = {
+    note?: string;
+    base64Contents?: string;
+};
+
+class ReqBodyValidator extends Validator<ReqBody> {
+    constructor() {
+        super('message body');
+
+        this.ruleFor('base64Contents')
+            .mustAsync(beProperlyBase64Encoded)
+            .when((reqBody) => reqBody.base64Contents !== undefined);
+    }
+}
+
+type ResBody = { document: s.documents.JSONSelectable };
+
+/**
+ * Update my document.
+ * @param req HTTP request.
+ * @param res HTTP response.
+ * @returns Nothing.
+ */
+const patchMyDocument = controller(async (req: Request<Params, ResBody, ReqBody>, res: Response<ResBody>): Promise<void> => {
+    await new ParamsValidator().validateAndThrow(req.params);
+    await new ReqBodyValidator().validateAndThrow(req.body);
+
+    // Make sure that the calling user is associated with the document
+    if ((await documentRepository.get(req.params.document, undefined, req.user.sub)).length === 0) {
+        throw new NotAuthorizedException();
+    }
+
+    try {
+        if (req.body.note !== null && req.body.note !== undefined) {
+            await documentRepository.update(req.params.document, req.body.note);
+        }
+        if (req.body.base64Contents !== null && req.body.base64Contents !== undefined) {
+            const key = `resume-reviews/${req.params.resumeReview}/documents/${req.params.document}`;
+            await s3Repository.upload(key, req.body.base64Contents, 'base64');
+        }
+    } catch (err) {
+        throw new InternalServerErrorException({ issue: 'Failed to update note or base64Contents. Try again with same data.' }, err);
+    }
+
+    res.status(204).end();
+});
+
+export default patchMyDocument;

--- a/api/src/controllers/resumeReview/getAllResumeReviews.test.ts
+++ b/api/src/controllers/resumeReview/getAllResumeReviews.test.ts
@@ -18,6 +18,10 @@ beforeEach(() => {
     next = jest.fn();
 });
 
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
 it('rejects non-uuid id query parameter', async () => {
     req.query = { id: `not-a-uuid` };
 

--- a/api/src/controllers/resumeReview/getMyResumeReviews.test.ts
+++ b/api/src/controllers/resumeReview/getMyResumeReviews.test.ts
@@ -18,6 +18,10 @@ beforeEach(() => {
     next = jest.fn();
 });
 
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
 it('rejects non-uuid id query parameter', async () => {
     req.query = { id: `not-a-uuid` };
 

--- a/api/src/controllers/resumeReview/postResumeReview.test.ts
+++ b/api/src/controllers/resumeReview/postResumeReview.test.ts
@@ -21,6 +21,10 @@ beforeEach(() => {
     next = jest.fn();
 });
 
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
 it('rejects improperly encoded reviewee for reviewee', async () => {
     req.body = { reviewee: '%E0%A4%A' };
 

--- a/api/src/controllers/user/postUser.test.ts
+++ b/api/src/controllers/user/postUser.test.ts
@@ -35,6 +35,10 @@ beforeEach(() => {
     next = jest.fn();
 });
 
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
 it('rejects null id', async () => {
     req.body.id = null;
 

--- a/api/src/controllers/validation.test.ts
+++ b/api/src/controllers/validation.test.ts
@@ -262,16 +262,16 @@ class TestValidDocumentResumeReviewValidator extends Validator<TestValidDocument
     }
 }
 
-describe('beAValidUser helper', () => {
+describe('beAValidDocument helper', () => {
     const v = new TestValidDocumentResumeReviewValidator();
 
-    it('does not throw if resume review exists', async () => {
+    it('does not throw if document exists', async () => {
         mockDocumentRepository.get.mockResolvedValueOnce([testConstants.document1]);
 
         await expect(v.validateAndThrow({ a: '67e8ff47-8c31-4725-885c-e0e40455e7f5' })).resolves.not.toThrowError(ValidationException);
     });
 
-    it('throws if resume review does not exist', async () => {
+    it('throws if document does not exist', async () => {
         mockDocumentRepository.get.mockResolvedValueOnce([]);
 
         await expect(v.validateAndThrow({ a: '67e8ff47-8c31-4725-885c-e0e40455e7f5' })).rejects.toThrowError(ValidationException);

--- a/api/src/controllers/validation.ts
+++ b/api/src/controllers/validation.ts
@@ -2,6 +2,7 @@ import { AsyncValidator as AsyncFluentValidator } from 'fluentvalidation-ts';
 import { validate as uuidValidate } from 'uuid';
 
 import ValidationException from '../exceptions/ValidationException';
+import * as documentRepository from '../repositories/documentRepository';
 import * as resumeReviewRepository from '../repositories/resumeReviewRepository';
 import * as userRepository from '../repositories/userRepository';
 
@@ -132,5 +133,19 @@ const beAValidResumeReview = {
     message: 'Must be a resume review that already exists',
 };
 
-export { beAResumeReviewState, beAValidResumeReview, beAValidUrl, beAValidUser, beAValidUuid, beProperlyBase64Encoded, beProperlyUriEncoded };
+/**
+ * Test whether a document already exists in the database.
+ */
+const beAValidDocument = {
+    predicate: async (field: string | undefined): Promise<boolean> => {
+        if (field === undefined || field === null) {
+            return false;
+        }
+        const matches = await documentRepository.get(field);
+        return matches.length == 1;
+    },
+    message: 'Must be a document that already exists',
+};
+
+export { beAResumeReviewState, beAValidDocument, beAValidResumeReview, beAValidUrl, beAValidUser, beAValidUuid, beProperlyBase64Encoded, beProperlyUriEncoded };
 export default Validator;

--- a/api/src/repositories/documentRepository.ts
+++ b/api/src/repositories/documentRepository.ts
@@ -26,4 +26,25 @@ const remove = async (id: string): Promise<s.documents.JSONSelectable[]> => {
     return db.deletes('documents', where).run(pool);
 };
 
-export { create, remove };
+/**
+ * Get documents. Filter as necessary.
+ * @param id Optional document id to filter by.
+ * @param resumeReviewId Optional resume review id to filter by.
+ * @param userId Optional user id to filter by.
+ * @returns List of documents appropriately filtered.
+ */
+const get = async (id?: string, resumeReviewId?: string, userId?: string): Promise<s.documents.JSONSelectable[]> => {
+    const where: s.documents.Whereable = {};
+    if (id) {
+        where.id = dc.eq(id);
+    }
+    if (resumeReviewId) {
+        where.resume_review_id = dc.eq(resumeReviewId);
+    }
+    if (userId) {
+        where.user_id = dc.eq(userId);
+    }
+    return db.select('documents', where).run(pool);
+};
+
+export { create, get, remove };

--- a/api/src/repositories/documentRepository.ts
+++ b/api/src/repositories/documentRepository.ts
@@ -47,4 +47,15 @@ const get = async (id?: string, resumeReviewId?: string, userId?: string): Promi
     return db.select('documents', where).run(pool);
 };
 
-export { create, get, remove };
+/**
+ * Update a document.
+ * @param id Id of document to update.
+ * @param note Value to update note to.
+ * @returns Updated document.
+ */
+const update = async (id: string, note?: string): Promise<s.documents.JSONSelectable[]> => {
+    const where: s.documents.Whereable = { id: dc.eq(id) };
+    return db.update('documents', { note: note }, where).run(pool);
+};
+
+export { create, get, remove, update };

--- a/api/src/routes/documentRoutes.ts
+++ b/api/src/routes/documentRoutes.ts
@@ -16,11 +16,7 @@ router.get('/resume-reviews/:resumeReview/documents', middleware.authorize(Scope
 
 router.post('/resume-reviews/:resumeReview/documents', middleware.authorize(Scope.CreateDocuments), controller.postDocument);
 
-router.patch('/resume-reviews/:resumeReview/documents/:document', middleware.authorizeAndFallThrough(Scope.UpdateAllDocuments), () => {
-    throw new NotImplementedException('PATCH /resume-reviews/:resumeReview/documents/:document');
-});
-router.patch('/resume-reviews/:resumeReview/documents/:document', middleware.authorize(Scope.UpdateMyDocuments), () => {
-    throw new NotImplementedException('PATCH /resume-reviews/:resumeReview/documents/:document');
-});
+router.patch('/resume-reviews/:resumeReview/documents/:document', middleware.authorizeAndFallThrough(Scope.UpdateAllDocuments), controller.patchAllDocument);
+router.patch('/resume-reviews/:resumeReview/documents/:document', middleware.authorize(Scope.UpdateMyDocuments), controller.patchMyDocument);
 
 export default router;


### PR DESCRIPTION
# Overview

Implement patch document endpoint. Dependent on #158 merging first.

# Changes

-  Implement patch my document endpoint
- Implement patch all document endpoint
- Add `afterEach` to all controller tests to reset mock counts and implementations.

# Notes

`patchMyDocument` is kind of awkward phrasing but it needs to be singular b/c it only updates one. I really should have made all the scopes in the format `<ACTION>:any_<RESOURCE>` b/c `any` works with both singular e.g. `updateAnyDocument` and with plural `getAnyDocuments`. Now that we have infrastructure as code for Auth0 I might make a PR to go in and change this. 

Let me know if people agree that I should make this change and it would be an improvement.

# Issue tracking

Closes #81 

# Testing & Demo

```bash
curl localhost:1337/api/v1/resume-reviews/07868828-f064-4db9-9553-f312e54ef485/documents/2e1895b1-a2fa-4d9c-9acf-28c5a4fb70ea -H "$(npx ts-node tools/getAuth.ts reviewer)" -v -s --data '{"base64Contents": "'"$(cat README.md | base64 -w 0)"'"}' -H 'Content-Type: application/json' -X PATCH -H 'Expect:'
```
