### PR TITLE
Fix cors

### DIFF
--- a/api/src/controllers/middleware.test.ts
+++ b/api/src/controllers/middleware.test.ts
@@ -213,6 +213,8 @@ describe('cors middleware', () => {
 
     it('cors header is attached', () => {
         corsMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+
+        expect(mockResponse.setHeader).toBeCalledTimes(2);
         expect(mockResponse.setHeader).toBeCalledWith('Access-Control-Allow-Origin', 'http://example.com');
     });
 
@@ -222,7 +224,8 @@ describe('cors middleware', () => {
         };
 
         corsMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
-        expect(mockResponse.setHeader).not.toBeCalled();
+
+        expect(mockResponse.setHeader).toBeCalledTimes(1);
     });
 
     it.each(['https://staging.example.com', 'https://prefix--staging.example.com'])('handles wildcards', (origin) => {
@@ -232,6 +235,7 @@ describe('cors middleware', () => {
 
         corsMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
 
+        expect(mockResponse.setHeader).toBeCalledTimes(2);
         expect(mockResponse.setHeader).toBeCalledWith('Access-Control-Allow-Origin', origin);
     });
 });

--- a/api/src/controllers/middleware.test.ts
+++ b/api/src/controllers/middleware.test.ts
@@ -214,7 +214,7 @@ describe('cors middleware', () => {
     it('cors header is attached', () => {
         corsMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
 
-        expect(mockResponse.setHeader).toBeCalledTimes(2);
+        expect(mockResponse.setHeader).toBeCalledTimes(2); // Experimentally discovered. Proves cors is being used.
         expect(mockResponse.setHeader).toBeCalledWith('Access-Control-Allow-Origin', 'http://example.com');
     });
 

--- a/api/src/controllers/middleware.ts
+++ b/api/src/controllers/middleware.ts
@@ -158,12 +158,7 @@ function customizedCors(): Middleware {
     const allowedOriginsRegExp = allowedOrigins.map((allowedOrigin) => new RegExp(allowedOrigin.replace('*', '[\\w-]*')));
 
     return cors({
-        origin: (origin, callback) => {
-            if (allowedOriginsRegExp.some((allowedOriginRegExp) => origin?.match(allowedOriginRegExp))) {
-                callback(null, true);
-            }
-            callback(null);
-        },
+        origin: allowedOriginsRegExp,
     });
 }
 


### PR DESCRIPTION
# Overview

All server endpoints were broken from #175 because it tried to set the headers after the request has been sent back to the client. I'm guessing there's a race condition in cors but it seems to be removed once I use the built-in regex handler for `origin`

# Changes

* Delegate regex handling to `cors` entirely

# Questions & Notes

# Issue tracking

Closes #178

# Testing & Demo

Preview deployment no longer shows 500 error