### PR TITLE
Add create resume review thunk

### DIFF
--- a/www/src/redux/substores/student/thunks/initiateResumeReview.test.tsx
+++ b/www/src/redux/substores/student/thunks/initiateResumeReview.test.tsx
@@ -1,0 +1,53 @@
+import { BaseThunkAPI } from '@reduxjs/toolkit/dist/createAsyncThunk';
+import { AxiosResponse } from 'axios';
+import { mocked } from 'ts-jest/utils';
+
+import postWithToken from '../../../../util/auth0/postWithToken';
+import { postDocuments, postResumeReviews } from '../../../../util/endpoints';
+import Scope from '../../../../util/scopes';
+import { Document, ResumeReview } from '../../../../util/serverResponses';
+import tc from '../../../../util/testConstants';
+import { StudentDispatch, StudentState } from '../studentStore';
+import { initiateResumeReview, InitiateResumeReviewParams } from './initiateResumeReview';
+
+jest.mock('../../../../util/auth0/postWithToken');
+const postWithTokenMock = mocked(postWithToken, true);
+
+const getTokenSilentlyMock = jest.fn();
+const rejectWithValueMock = jest.fn();
+const thunkApiMock = {
+    rejectWithValue: rejectWithValueMock,
+} as unknown as BaseThunkAPI<StudentState, unknown, StudentDispatch, string>;
+
+const params: InitiateResumeReviewParams = {
+    userId: tc.user1.id,
+    base64Contents: 'base64',
+    tokenAcquirer: getTokenSilentlyMock,
+};
+
+it('works on happy path', async () => {
+    const postResumeReviewMockResponse = {
+        data: tc.resumeReview1,
+    };
+    const postDocumentMockResponse = {
+        data: tc.document1,
+    };
+    postWithTokenMock.mockResolvedValueOnce(postResumeReviewMockResponse as AxiosResponse<ResumeReview>);
+    postWithTokenMock.mockResolvedValueOnce(postDocumentMockResponse as AxiosResponse<Document>);
+
+    const result = await initiateResumeReview(params, thunkApiMock);
+
+    expect(postWithTokenMock).toBeCalledWith(postResumeReviews, getTokenSilentlyMock, [Scope.CreateResumeReviews], {
+        reviewee: params.userId,
+    });
+    expect(postWithTokenMock).toBeCalledWith(postDocuments(tc.resumeReview1.id), getTokenSilentlyMock, [Scope.CreateDocuments], {
+        note: '',
+        isReview: false,
+        userId: params.userId,
+        base64Contents: params.base64Contents,
+    });
+    expect(result).toStrictEqual({
+        resumeReview: tc.resumeReview1,
+        document: tc.document1,
+    });
+});

--- a/www/src/redux/substores/student/thunks/initiateResumeReview.tsx
+++ b/www/src/redux/substores/student/thunks/initiateResumeReview.tsx
@@ -38,22 +38,18 @@ type PayloadCreatorReturn = {
 export const initiateResumeReview = async (params: InitiateResumeReviewParams): Promise<PayloadCreatorReturn> => {
     const resumeReviewResult = await postWithToken<ResumeReviewBody, ResumeReview>(postResumeReviews, params.tokenAcquirer, [Scope.CreateResumeReviews], {
         reviewee: params.userId,
-    });
-
-    if (resumeReviewResult?.data === undefined) {
+    }).catch(() => {
         throw new Error('Unable to create resume review object');
-    }
+    });
 
     const documentResult = await postWithToken<DocumentBody, Document>(postDocuments(resumeReviewResult?.data.id ?? ''), params.tokenAcquirer, [Scope.CreateDocuments], {
         note: '',
         isReview: false,
         userId: params.userId,
         base64Contents: params.base64Contents,
-    });
-
-    if (documentResult?.data === undefined) {
+    }).catch(() => {
         throw new Error('Unable to upload document');
-    }
+    });
 
     return {
         resumeReview: resumeReviewResult?.data,

--- a/www/src/redux/substores/student/thunks/initiateResumeReview.tsx
+++ b/www/src/redux/substores/student/thunks/initiateResumeReview.tsx
@@ -1,0 +1,26 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import postWithToken from '../../../../util/auth0/postWithToken';
+import TokenAcquirer from '../../../../util/auth0/TokenAcquirer';
+import { resumeReviews } from '../../../../util/endpoints';
+import Scope from '../../../../util/scopes';
+import { ResumeReview } from '../../../../util/serverResponses';
+
+export type InitiateResumeReviewParams = {
+    reviewee: string;
+    tokenAcquirer: TokenAcquirer;
+};
+
+type ResumeReviewBody = {
+    reviewee: string;
+};
+
+const initiateResumeReview = async (params: InitiateResumeReviewParams) => {
+    const res = await postWithToken<ResumeReviewBody, ResumeReview>(resumeReviews, params.tokenAcquirer, [Scope.CreateResumeReviews], {
+        reviewee: params.reviewee,
+    });
+
+    return res;
+};
+
+export default createAsyncThunk('resumeReview/initiate', initiateResumeReview);

--- a/www/src/redux/substores/student/thunks/initiateResumeReview.tsx
+++ b/www/src/redux/substores/student/thunks/initiateResumeReview.tsx
@@ -1,10 +1,12 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
+import { BaseThunkAPI } from '@reduxjs/toolkit/dist/createAsyncThunk';
 
 import postWithToken from '../../../../util/auth0/postWithToken';
 import TokenAcquirer from '../../../../util/auth0/TokenAcquirer';
 import { postDocuments, postResumeReviews } from '../../../../util/endpoints';
 import Scope from '../../../../util/scopes';
 import { Document, ResumeReview } from '../../../../util/serverResponses';
+import { StudentDispatch, StudentState } from '../studentStore';
 
 export type InitiateResumeReviewParams = {
     userId: string;
@@ -23,13 +25,24 @@ type DocumentBody = {
     base64Contents: string;
 };
 
-const initiateResumeReview = async (params: InitiateResumeReviewParams) => {
+type AsyncThunkConfig = {
+    state: StudentState;
+    dispatch: StudentDispatch;
+    rejectValue: string;
+};
+
+type PayloadCreatorReturn = {
+    resumeReview?: ResumeReview;
+    document?: Document;
+};
+
+const initiateResumeReview = async (params: InitiateResumeReviewParams, thunkAPI: BaseThunkAPI<StudentState, unknown, StudentDispatch, string>) => {
     const resumeReviewResult = await postWithToken<ResumeReviewBody, ResumeReview>(postResumeReviews, params.tokenAcquirer, [Scope.CreateResumeReviews], {
         reviewee: params.userId,
     });
 
     if (resumeReviewResult?.data === undefined) {
-        // TODO: Reject with thunkApi
+        return thunkAPI.rejectWithValue('Unable to create resume review object');
     }
 
     const documentResult = await postWithToken<DocumentBody, Document>(postDocuments(resumeReviewResult?.data.id ?? ''), params.tokenAcquirer, [Scope.CreateDocuments], {
@@ -39,10 +52,14 @@ const initiateResumeReview = async (params: InitiateResumeReviewParams) => {
         base64Contents: params.base64Contents,
     });
 
+    if (documentResult?.data === undefined) {
+        return thunkAPI.rejectWithValue('Unable to upload document');
+    }
+
     return {
         resumeReview: resumeReviewResult?.data,
         document: documentResult?.data,
     };
 };
 
-export default createAsyncThunk('resumeReview/initiate', initiateResumeReview);
+export default createAsyncThunk<PayloadCreatorReturn, InitiateResumeReviewParams, AsyncThunkConfig>('resumeReview/initiate', initiateResumeReview);

--- a/www/src/redux/substores/student/thunks/initiateResumeReview.tsx
+++ b/www/src/redux/substores/student/thunks/initiateResumeReview.tsx
@@ -2,12 +2,13 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import postWithToken from '../../../../util/auth0/postWithToken';
 import TokenAcquirer from '../../../../util/auth0/TokenAcquirer';
-import { resumeReviews } from '../../../../util/endpoints';
+import { postDocuments, postResumeReviews } from '../../../../util/endpoints';
 import Scope from '../../../../util/scopes';
-import { ResumeReview } from '../../../../util/serverResponses';
+import { Document, ResumeReview } from '../../../../util/serverResponses';
 
 export type InitiateResumeReviewParams = {
-    reviewee: string;
+    userId: string;
+    base64Contents: string;
     tokenAcquirer: TokenAcquirer;
 };
 
@@ -15,12 +16,33 @@ type ResumeReviewBody = {
     reviewee: string;
 };
 
+type DocumentBody = {
+    note: string;
+    isReview: boolean;
+    userId: string;
+    base64Contents: string;
+};
+
 const initiateResumeReview = async (params: InitiateResumeReviewParams) => {
-    const res = await postWithToken<ResumeReviewBody, ResumeReview>(resumeReviews, params.tokenAcquirer, [Scope.CreateResumeReviews], {
-        reviewee: params.reviewee,
+    const resumeReviewResult = await postWithToken<ResumeReviewBody, ResumeReview>(postResumeReviews, params.tokenAcquirer, [Scope.CreateResumeReviews], {
+        reviewee: params.userId,
     });
 
-    return res;
+    if (resumeReviewResult?.data === undefined) {
+        // TODO: Reject with thunkApi
+    }
+
+    const documentResult = await postWithToken<DocumentBody, Document>(postDocuments(resumeReviewResult?.data.id ?? ''), params.tokenAcquirer, [Scope.CreateDocuments], {
+        note: '',
+        isReview: false,
+        userId: params.userId,
+        base64Contents: params.base64Contents,
+    });
+
+    return {
+        resumeReview: resumeReviewResult?.data,
+        document: documentResult?.data,
+    };
 };
 
 export default createAsyncThunk('resumeReview/initiate', initiateResumeReview);

--- a/www/src/redux/thunks/checkUserRegistration.test.ts
+++ b/www/src/redux/thunks/checkUserRegistration.test.ts
@@ -2,7 +2,7 @@ import { AxiosResponse } from 'axios';
 import { mocked } from 'ts-jest/utils';
 
 import fetchWithToken from '../../util/auth0/fetchWithToken';
-import { me } from '../../util/endpoints';
+import { getMe } from '../../util/endpoints';
 import { WrappedUser } from '../../util/serverResponses';
 import tc from '../../util/testConstants';
 import { checkUserRegistration } from './checkUserRegistration';
@@ -22,7 +22,7 @@ it('returns the user if the user exists', async () => {
 
     const result = await checkUserRegistration(getTokenSilentlyMock);
 
-    expect(fetchWithTokenMock).toBeCalledWith(me, getTokenSilentlyMock);
+    expect(fetchWithTokenMock).toBeCalledWith(getMe, getTokenSilentlyMock);
     expect(result).toStrictEqual({ user: tc.user1 });
 });
 
@@ -31,6 +31,6 @@ it('null if the user does not exist (server returns 404)', async () => {
 
     const result = await checkUserRegistration(getTokenSilentlyMock);
 
-    expect(fetchWithTokenMock).toBeCalledWith(me, getTokenSilentlyMock);
+    expect(fetchWithTokenMock).toBeCalledWith(getMe, getTokenSilentlyMock);
     expect(result).toBe(null);
 });

--- a/www/src/redux/thunks/checkUserRegistration.ts
+++ b/www/src/redux/thunks/checkUserRegistration.ts
@@ -2,12 +2,12 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import fetchWithToken from '../../util/auth0/fetchWithToken';
 import TokenAcquirer from '../../util/auth0/TokenAcquirer';
-import { me } from '../../util/endpoints';
+import { getMe } from '../../util/endpoints';
 import { WrappedUser } from '../../util/serverResponses';
 
 export const checkUserRegistration = async (tokenAcquirer: TokenAcquirer): Promise<WrappedUser | undefined | null> => {
     try {
-        const user = await fetchWithToken<WrappedUser>(me, tokenAcquirer);
+        const user = await fetchWithToken<WrappedUser>(getMe, tokenAcquirer);
         return user?.data;
     } catch (e) {
         return null;

--- a/www/src/redux/thunks/registerUser.test.ts
+++ b/www/src/redux/thunks/registerUser.test.ts
@@ -2,7 +2,7 @@ import { AxiosResponse } from 'axios';
 import { mocked } from 'ts-jest/utils';
 
 import postWithToken from '../../util/auth0/postWithToken';
-import { users } from '../../util/endpoints';
+import { postUsers } from '../../util/endpoints';
 import { WrappedUser } from '../../util/serverResponses';
 import tc from '../../util/testConstants';
 import { registerUser } from './registerUser';
@@ -27,7 +27,7 @@ it('returns the user if the registration succeeds', async () => {
         tokenAcquirer: getTokenSilentlyMock,
     });
 
-    expect(postWithTokenMock).toBeCalledWith(users, getTokenSilentlyMock, [], userInfo);
+    expect(postWithTokenMock).toBeCalledWith(postUsers, getTokenSilentlyMock, [], userInfo);
     expect(result).toStrictEqual({ user: tc.user1 });
 });
 
@@ -41,6 +41,6 @@ it('null if the registration fails', async () => {
         tokenAcquirer: getTokenSilentlyMock,
     });
 
-    expect(postWithTokenMock).toBeCalledWith(users, getTokenSilentlyMock, [], userInfo);
+    expect(postWithTokenMock).toBeCalledWith(postUsers, getTokenSilentlyMock, [], userInfo);
     expect(result).toBe(null);
 });

--- a/www/src/redux/thunks/registerUser.ts
+++ b/www/src/redux/thunks/registerUser.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import postWithToken from '../../util/auth0/postWithToken';
 import TokenAcquirer from '../../util/auth0/TokenAcquirer';
-import { users } from '../../util/endpoints';
+import { postUsers } from '../../util/endpoints';
 import { User } from '../../util/serverResponses';
 
 export type UserInfo = {
@@ -24,7 +24,7 @@ export type RegisterUserParameters = {
 
 export const registerUser = async ({ userInfo, tokenAcquirer }: RegisterUserParameters): Promise<User | undefined | null> => {
     try {
-        const response = await postWithToken<UserInfo, User>(users, tokenAcquirer, [], userInfo);
+        const response = await postWithToken<UserInfo, User>(postUsers, tokenAcquirer, [], userInfo);
         return response?.data;
     } catch (e) {
         return null;

--- a/www/src/util/auth0/postWithToken.ts
+++ b/www/src/util/auth0/postWithToken.ts
@@ -3,19 +3,14 @@ import axios, { AxiosResponse } from 'axios';
 import TokenAcquirer from './TokenAcquirer';
 
 const postWithToken = async <BodyType, ResponseType>(url: string, tokenAcquirer: TokenAcquirer, scopes?: string[], data?: BodyType): Promise<AxiosResponse<ResponseType> | undefined> => {
-    try {
-        const token = await tokenAcquirer({
-            scope: scopes?.join(' '),
-        });
-        return axios.post(url, data, {
-            headers: {
-                authorization: `Bearer ${token}`,
-            },
-        });
-    } catch (e) {
-        console.error(e);
-    }
-    return undefined;
+    const token = await tokenAcquirer({
+        scope: scopes?.join(' '),
+    });
+    return axios.post(url, data, {
+        headers: {
+            authorization: `Bearer ${token}`,
+        },
+    });
 };
 
 export default postWithToken;

--- a/www/src/util/endpoints.ts
+++ b/www/src/util/endpoints.ts
@@ -1,6 +1,7 @@
 import config from './config';
 
-export const me = `${config.server.endpoint}/api/v1/users/me`;
-export const users = `${config.server.endpoint}/api/v1/users`;
+export const getMe = `${config.server.endpoint}/api/v1/users/me`;
+export const postUsers = `${config.server.endpoint}/api/v1/users`;
 
-export const resumeReviews = `${config.server.endpoint}/api/v1/resume-reviews`;
+export const postResumeReviews = `${config.server.endpoint}/api/v1/resume-reviews`;
+export const postDocuments = (resumeReviewId: string): string => `${config.server.endpoint}/api/v1/resume-reviews/${resumeReviewId}/documents`;

--- a/www/src/util/endpoints.ts
+++ b/www/src/util/endpoints.ts
@@ -2,3 +2,5 @@ import config from './config';
 
 export const me = `${config.server.endpoint}/api/v1/users/me`;
 export const users = `${config.server.endpoint}/api/v1/users`;
+
+export const resumeReviews = `${config.server.endpoint}/api/v1/resume-reviews`;

--- a/www/src/util/scopes.ts
+++ b/www/src/util/scopes.ts
@@ -1,0 +1,25 @@
+enum Scope {
+    ReadUsers = 'read:users',
+    ReadRoles = 'read:roles',
+    CreateRoles = 'create:roles',
+    DeleteRoles = 'delete:roles',
+    ReadMyResumeReviews = 'read_my:resume_reviews',
+    ReadAllResumeReviews = 'read_all:resume_reviews',
+    CreateResumeReviews = 'create:resume_reviews',
+    UpdateMyResumeReviews = 'update_my:resume_reviews',
+    UpdateAllResumeReviews = 'update_all:resume_reviews',
+    ReadMyDocuments = 'read_my:documents',
+    ReadAllDocuments = 'read_all:documents',
+    CreateDocuments = 'create:documents',
+    UpdateMyDocuments = 'update_my:documents',
+    UpdateAllDocuments = 'update_all:documents',
+    ReadTimeSlots = 'read:time_slots',
+    CreateTimeSlots = 'create:time_slots',
+    DeleteTimeSlots = 'delete:time_slots',
+    ReadMyInterviews = 'read_my:interviews',
+    ReadAllInterviews = 'read_all:interviews',
+    CreateInterviews = 'create:interviews',
+    DeleteInterviews = 'delete:interviews',
+}
+
+export default Scope;

--- a/www/src/util/serverResponses.d.ts
+++ b/www/src/util/serverResponses.d.ts
@@ -1,10 +1,3 @@
-export declare type DateString = `${number}-${number}-${number}`;
-export declare type TimeString = `${number}:${number}${'' | `:${number}`}`;
-export declare type TzSuffix = 'Z' | `${'+' | '-'}${number}${'' | `:${number}`}`;
-export declare type TimeTzString = `${TimeString}${TzSuffix}`;
-export declare type TimestampString = `${DateString}T${TimeString}`;
-export type TimestampTzString = `${TimestampString}${TzSuffix}`; // ISO8601-formatted date and time string **with no timezone**
-
 export type User = {
     id: string;
     email: string;
@@ -15,21 +8,29 @@ export type User = {
     family_name: string;
     full_name: string;
     photo_url: string | null;
-    created_at: TimestampTzString;
-    updated_at: TimestampTzString;
+    created_at: string;
+    updated_at: string;
 };
 
 export type WrappedUser = {
     user: User;
 };
 
-export type resumeReviewState = 'canceled' | 'finished' | 'reviewing' | 'seeking_reviewer';
-
 export type ResumeReview = {
     id: string;
     revieweeId: string;
     reviewerId: string | null;
-    state: resumeReviewState;
-    createdAt: TimestampTzString;
-    updatedAt: TimestampTzString;
+    state: 'canceled' | 'finished' | 'reviewing' | 'seeking_reviewer';
+    createdAt: string;
+    updatedAt: string;
+};
+
+export type Document = {
+    id: string;
+    note: string;
+    isReview: boolean;
+    userId: string;
+    resumeReviewId: string;
+    createdAt: string;
+    updatedAt: string;
 };

--- a/www/src/util/serverResponses.d.ts
+++ b/www/src/util/serverResponses.d.ts
@@ -22,3 +22,14 @@ export type User = {
 export type WrappedUser = {
     user: User;
 };
+
+export type resumeReviewState = 'canceled' | 'finished' | 'reviewing' | 'seeking_reviewer';
+
+export type ResumeReview = {
+    id: string;
+    revieweeId: string;
+    reviewerId: string | null;
+    state: resumeReviewState;
+    createdAt: TimestampTzString;
+    updatedAt: TimestampTzString;
+};

--- a/www/src/util/serverResponses.d.ts
+++ b/www/src/util/serverResponses.d.ts
@@ -1,3 +1,10 @@
+export declare type DateString = `${number}-${number}-${number}`;
+export declare type TimeString = `${number}:${number}${'' | `:${number}`}`;
+export declare type TzSuffix = 'Z' | `${'+' | '-'}${number}${'' | `:${number}`}`;
+export declare type TimeTzString = `${TimeString}${TzSuffix}`;
+export declare type TimestampString = `${DateString}T${TimeString}`;
+export type TimestampTzString = `${TimestampString}${TzSuffix}`; // ISO8601-formatted date and time string **with no timezone**
+
 export type User = {
     id: string;
     email: string;
@@ -8,8 +15,8 @@ export type User = {
     family_name: string;
     full_name: string;
     photo_url: string | null;
-    created_at: db.TimestampTzString;
-    updated_at: db.TimestampTzString;
+    created_at: TimestampTzString;
+    updated_at: TimestampTzString;
 };
 
 export type WrappedUser = {

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -1,4 +1,4 @@
-import { ResumeReview, User } from './serverResponses';
+import { Document, ResumeReview, User } from './serverResponses';
 
 const user1: User = {
     id: 'google-oauth2|999937999992352499990',
@@ -23,4 +23,14 @@ const resumeReview1: ResumeReview = {
     updatedAt: '2021-06-14T06:09:19.373404+00:00',
 };
 
-export default { user1, resumeReview1 };
+const document1: Document = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    note: '',
+    isReview: false,
+    userId: user1.id,
+    resumeReviewId: '123e4567-e89b-12d3-a456-426614174000',
+    createdAt: '2021-06-14T06:09:19.373404+00:00',
+    updatedAt: '2021-06-14T06:09:19.373404+00:00',
+};
+
+export default { user1, resumeReview1, document1 };

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -1,4 +1,4 @@
-import { User } from './serverResponses';
+import { ResumeReview, User } from './serverResponses';
 
 const user1: User = {
     id: 'google-oauth2|999937999992352499990',
@@ -14,4 +14,13 @@ const user1: User = {
     updated_at: '2021-06-14T06:09:19.373404+00:00',
 };
 
-export default { user1 };
+const resumeReview1: ResumeReview = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    revieweeId: user1.id,
+    reviewerId: null,
+    state: 'seeking_reviewer',
+    createdAt: '2021-06-14T06:09:19.373404+00:00',
+    updatedAt: '2021-06-14T06:09:19.373404+00:00',
+};
+
+export default { user1, resumeReview1 };


### PR DESCRIPTION
# Overview

Allows front end component to easily post the resume review data to the server as

```ts
    const dispatch = useStudentDispatch();

    dispatch(
        initiateResumeReview({
            userId: user?.sub ?? '',
            tokenAcquirer: getAccessTokenSilently,
            base64Contents: 'base64contentx',
        }),
    );
```

# Changes

* Add service call in non-exported `initiateResumeReview`
* Add thunk wrapped call in default export `initiateResumeReview`
* Prefix endpoints with `get` and `post` accordingly
* Delegate try catch for `postWithToken` and `fetchWithToken` to user
* Copy scopes from server
* Replace `db.TimestampTzString` to simply `string`

# Questions & Notes

* Might want to revisit to clean up the redux types
* Sadly `expect(async () => ...).toThrow(...)` [doesn't work](https://github.com/facebook/jest/issues/1700) and best syntax I could find looks like [`await expect(check).rejects.toThrow('error string')`](https://github.com/facebook/jest/issues/1700#issuecomment-386019524)

# Issue tracking

TODO

# Testing & Demo

Refer to unit tests