### PR TITLE
Fetch resume reviews on student app

### DIFF
--- a/www/src/redux/substores/student/slices/resumeReviewSlice.ts
+++ b/www/src/redux/substores/student/slices/resumeReviewSlice.ts
@@ -5,13 +5,11 @@ import getMyResumeReviews from '../thunks/getMyResumeReviews';
 
 type InitialState = {
     resumeReviews: ResumeReview[];
-    currentResume: string | null; // base64encoded contents
     isLoading: boolean;
 };
 
 const initialState: InitialState = {
     resumeReviews: [],
-    currentResume: null,
     isLoading: false,
 };
 

--- a/www/src/redux/substores/student/slices/resumeReviewSlice.ts
+++ b/www/src/redux/substores/student/slices/resumeReviewSlice.ts
@@ -3,12 +3,12 @@ import { createSlice } from '@reduxjs/toolkit';
 import { ResumeReview } from '../../../../util/serverResponses';
 import getMyResumeReviews from '../thunks/getMyResumeReviews';
 
-type InitialState = {
+type ResumeReviewState = {
     resumeReviews: ResumeReview[];
     isLoading: boolean;
 };
 
-const initialState: InitialState = {
+const initialState: ResumeReviewState = {
     resumeReviews: [],
     isLoading: false,
 };

--- a/www/src/redux/substores/student/slices/resumeReviewSlice.ts
+++ b/www/src/redux/substores/student/slices/resumeReviewSlice.ts
@@ -22,6 +22,7 @@ export const resumeReviewSlice = createSlice({
             state.isLoading = true;
         });
         builder.addCase(getMyResumeReviews.fulfilled, (state, action) => {
+            state.isLoading = false;
             state.resumeReviews = action.payload.resumeReviews;
         });
     },

--- a/www/src/redux/substores/student/slices/resumeReviewSlice.ts
+++ b/www/src/redux/substores/student/slices/resumeReviewSlice.ts
@@ -1,12 +1,32 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import { ResumeReview } from '../../../../util/serverResponses';
+import getMyResumeReviews from '../thunks/getMyResumeReviews';
+
+type InitialState = {
+    resumeReviews: ResumeReview[];
+    currentResume: string | null; // base64encoded contents
+    isLoading: boolean;
+};
+
+const initialState: InitialState = {
+    resumeReviews: [],
+    currentResume: null,
+    isLoading: false,
+};
+
 export const resumeReviewSlice = createSlice({
     name: 'resumeReview',
-    initialState: {
-        resumes: [],
-        currentResume: null,
-    },
+    initialState,
     reducers: {},
+    extraReducers: (builder) => {
+        builder.addCase(getMyResumeReviews.pending, (state) => {
+            state.isLoading = true;
+        });
+        builder.addCase(getMyResumeReviews.fulfilled, (state, action) => {
+            state.resumeReviews = action.payload.resumeReviews;
+        });
+    },
 });
 
 export default resumeReviewSlice.reducer;

--- a/www/src/redux/substores/student/thunks/getMyResumeReviews.tsx
+++ b/www/src/redux/substores/student/thunks/getMyResumeReviews.tsx
@@ -1,0 +1,37 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import postWithToken from '../../../../util/auth0/postWithToken';
+import TokenAcquirer from '../../../../util/auth0/TokenAcquirer';
+import { postResumeReviews } from '../../../../util/endpoints';
+import Scope from '../../../../util/scopes';
+import { WrappedResumeReviews } from '../../../../util/serverResponses';
+import { StudentDispatch, StudentState } from '../studentStore';
+
+export type InitiateResumeReviewParams = {
+    userId: string;
+    base64Contents: string;
+    tokenAcquirer: TokenAcquirer;
+};
+
+type AsyncThunkConfig = {
+    state: StudentState;
+    dispatch: StudentDispatch;
+    rejectValue: string;
+};
+
+export const getMyResumeReviews = async (params: InitiateResumeReviewParams): Promise<WrappedResumeReviews> => {
+    const resumeReviewResult = await postWithToken<unknown, WrappedResumeReviews>(postResumeReviews, params.tokenAcquirer, [Scope.ReadMyResumeReviews], {
+        reviewee: params.userId,
+    }).catch(() => {
+        throw new Error('Unable to fetch resume reviews');
+    });
+    return resumeReviewResult?.data ?? { resumeReviews: [] };
+};
+
+export default createAsyncThunk<WrappedResumeReviews, InitiateResumeReviewParams, AsyncThunkConfig>('resumeReview/initiate', (params, thunkApi) => {
+    try {
+        return getMyResumeReviews(params);
+    } catch (e) {
+        return thunkApi.rejectWithValue(e);
+    }
+});

--- a/www/src/redux/substores/student/thunks/getMyResumeReviews.tsx
+++ b/www/src/redux/substores/student/thunks/getMyResumeReviews.tsx
@@ -1,15 +1,13 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
-import postWithToken from '../../../../util/auth0/postWithToken';
+import fetchWithToken from '../../../../util/auth0/fetchWithToken';
 import TokenAcquirer from '../../../../util/auth0/TokenAcquirer';
-import { postResumeReviews } from '../../../../util/endpoints';
+import { getResumeReviews } from '../../../../util/endpoints';
 import Scope from '../../../../util/scopes';
 import { WrappedResumeReviews } from '../../../../util/serverResponses';
 import { StudentDispatch, StudentState } from '../studentStore';
 
 export type InitiateResumeReviewParams = {
-    userId: string;
-    base64Contents: string;
     tokenAcquirer: TokenAcquirer;
 };
 
@@ -20,9 +18,7 @@ type AsyncThunkConfig = {
 };
 
 export const getMyResumeReviews = async (params: InitiateResumeReviewParams): Promise<WrappedResumeReviews> => {
-    const resumeReviewResult = await postWithToken<unknown, WrappedResumeReviews>(postResumeReviews, params.tokenAcquirer, [Scope.ReadMyResumeReviews], {
-        reviewee: params.userId,
-    }).catch(() => {
+    const resumeReviewResult = await fetchWithToken<WrappedResumeReviews>(getResumeReviews, params.tokenAcquirer, [Scope.ReadMyResumeReviews]).catch(() => {
         throw new Error('Unable to fetch resume reviews');
     });
     return resumeReviewResult?.data ?? { resumeReviews: [] };

--- a/www/src/redux/substores/student/thunks/getMyResumeReviews.tsx
+++ b/www/src/redux/substores/student/thunks/getMyResumeReviews.tsx
@@ -24,7 +24,7 @@ export const getMyResumeReviews = async (params: InitiateResumeReviewParams): Pr
     return resumeReviewResult?.data ?? { resumeReviews: [] };
 };
 
-export default createAsyncThunk<WrappedResumeReviews, InitiateResumeReviewParams, AsyncThunkConfig>('resumeReview/initiate', (params, thunkApi) => {
+export default createAsyncThunk<WrappedResumeReviews, InitiateResumeReviewParams, AsyncThunkConfig>('resumeReview/getMyResumeReviews', (params, thunkApi) => {
     try {
         return getMyResumeReviews(params);
     } catch (e) {

--- a/www/src/routes/student/ResumeReview.test.tsx
+++ b/www/src/routes/student/ResumeReview.test.tsx
@@ -19,13 +19,21 @@ describe('StudentResumeReview', () => {
         },
     };
 
-    it('renders correctly', () => {
+    beforeEach(() => {
         useStudentDispatchMock.mockReturnValue(dispatchMock);
         useStudentSelectorMock.mockImplementation((selector) => selector(studentStateMock));
+    });
 
+    it('renders correctly', () => {
         render(<ResumeReview />);
 
         const componentsWithText = screen.getAllByText('Submit resume');
         expect(componentsWithText[0]).toBeInTheDocument();
+    });
+
+    it('calls getMyResumeReviews', () => {
+        render(<ResumeReview />);
+
+        expect(dispatchMock).toBeCalledTimes(1);
     });
 });

--- a/www/src/routes/student/ResumeReview.test.tsx
+++ b/www/src/routes/student/ResumeReview.test.tsx
@@ -1,10 +1,28 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { mocked } from 'ts-jest/utils';
 
+import { useStudentDispatch, useStudentSelector } from '../../redux/substores/student/studentHooks';
 import ResumeReview from './ResumeReview';
 
+jest.mock('../../redux/substores/student/studentHooks');
+const useStudentDispatchMock = mocked(useStudentDispatch, true);
+const useStudentSelectorMock = mocked(useStudentSelector, true);
+
 describe('StudentResumeReview', () => {
+    const dispatchMock = jest.fn();
+
+    const studentStateMock = {
+        resumeReview: {
+            resumeReviews: [],
+            isLoading: false,
+        },
+    };
+
     it('renders correctly', () => {
+        useStudentDispatchMock.mockReturnValue(dispatchMock);
+        useStudentSelectorMock.mockImplementation((selector) => selector(studentStateMock));
+
         render(<ResumeReview />);
 
         const componentsWithText = screen.getAllByText('Submit resume');

--- a/www/src/routes/student/ResumeReview.test.tsx
+++ b/www/src/routes/student/ResumeReview.test.tsx
@@ -3,11 +3,15 @@ import React from 'react';
 import { mocked } from 'ts-jest/utils';
 
 import { useStudentDispatch, useStudentSelector } from '../../redux/substores/student/studentHooks';
+import getMyResumeReviews from '../../redux/substores/student/thunks/getMyResumeReviews';
 import ResumeReview from './ResumeReview';
 
 jest.mock('../../redux/substores/student/studentHooks');
 const useStudentDispatchMock = mocked(useStudentDispatch, true);
 const useStudentSelectorMock = mocked(useStudentSelector, true);
+
+jest.mock('../../redux/substores/student/thunks/getMyResumeReviews');
+const getMyResumeReviewsMock = mocked(getMyResumeReviews, true);
 
 describe('StudentResumeReview', () => {
     const dispatchMock = jest.fn();
@@ -34,6 +38,6 @@ describe('StudentResumeReview', () => {
     it('calls getMyResumeReviews', () => {
         render(<ResumeReview />);
 
-        expect(dispatchMock).toBeCalledTimes(1);
+        expect(getMyResumeReviewsMock).toBeCalled();
     });
 });

--- a/www/src/routes/student/ResumeReview.tsx
+++ b/www/src/routes/student/ResumeReview.tsx
@@ -1,10 +1,26 @@
+import { useAuth0 } from '@auth0/auth0-react';
 import { Grid, Typography } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 
 import UploadResumeIcon from '../../assets/add_resume.svg';
+import { useStudentDispatch, useStudentSelector } from '../../redux/substores/student/studentHooks';
+import getMyResumeReviews from '../../redux/substores/student/thunks/getMyResumeReviews';
 
 const ResumeReview: FC = () => {
+    const { resumeReviews } = useStudentSelector((state) => state.resumeReview);
+    const { getAccessTokenSilently } = useAuth0();
+    const dispatch = useStudentDispatch();
+
+    useEffect(() => {
+        dispatch(getMyResumeReviews({ tokenAcquirer: getAccessTokenSilently }));
+    }, []);
+
+    useEffect(() => {
+        // TODO: display upload button if there are no resume reviews
+        console.debug(resumeReviews);
+    }, [resumeReviews]);
+
     return (
         <div style={{ overflow: 'hidden' }}>
             <Grid container justify='center' alignItems='center' spacing={8} style={{ marginTop: '10px', minHeight: '75vh' }}>

--- a/www/src/util/endpoints.ts
+++ b/www/src/util/endpoints.ts
@@ -1,7 +1,8 @@
 import config from './config';
 
 export const getMe = `${config.server.endpoint}/api/v1/users/me`;
-export const postUsers = `${config.server.endpoint}/api/v1/users`;
+export const getResumeReviews = `${config.server.endpoint}/api/v1/resume-reviews`;
 
+export const postUsers = `${config.server.endpoint}/api/v1/users`;
 export const postResumeReviews = `${config.server.endpoint}/api/v1/resume-reviews`;
 export const postDocuments = (resumeReviewId: string): string => `${config.server.endpoint}/api/v1/resume-reviews/${resumeReviewId}/documents`;

--- a/www/src/util/serverResponses.d.ts
+++ b/www/src/util/serverResponses.d.ts
@@ -25,6 +25,10 @@ export type ResumeReview = {
     updatedAt: string;
 };
 
+export type WrappedResumeReviews = {
+    resumeReviews: ResumeReview[];
+};
+
 export type Document = {
     id: string;
     note: string;


### PR DESCRIPTION
# Overview

* Fetch resume review objects when the user lands on the resume review page as a student

# Changes

* Implemented getMyResumeReviews thunk
* Integrated thunk with resumeReviewSlice


# Questions & Notes

* This will unblock #181 

# Issue tracking

Closes #186 

# Testing & Demo

Refer to unit tests