### PR TITLE
Integrate register button with redux

### DIFF
--- a/api/src/controllers/user/getMe.test.ts
+++ b/api/src/controllers/user/getMe.test.ts
@@ -33,12 +33,14 @@ it('returns 404 on user that does not exist', async () => {
 
     await getMe(req as Request<Params>, res as Response, next);
 
+    expect(res.status).toBeCalledTimes(1);
     expect(res.status).toBeCalledWith(404);
 });
 
 it('works on happy path', async () => {
     await getMe(req as Request<Params>, res as Response, next);
 
+    expect(res.status).toBeCalledTimes(1);
     expect(res.status).toBeCalledWith(200);
     expect(res.json).toBeCalledWith({ user: toCamelCase(testConstants.user1) });
 });

--- a/api/src/controllers/user/getMe.ts
+++ b/api/src/controllers/user/getMe.ts
@@ -18,10 +18,9 @@ const getMe = controller(async (req: Request, res: Response<ResBody>): Promise<v
     const id = req.user.sub;
     const matches = await userRepository.get(id);
 
-    const userExists = matches.length == 1;
-
+    const userExists = matches.length === 1;
     if (!userExists) {
-        res.status(404);
+        res.status(404).end();
     }
 
     res.status(200).json({ user: toCamelCase(matches[0]) });

--- a/www/src/App.test.tsx
+++ b/www/src/App.test.tsx
@@ -47,7 +47,7 @@ describe('App', () => {
         ${'admin'}       | ${'🚧 Work in progress 🚧'} | ${'an admin'}
     `('renders correctly for $friendlyName', ({ role, containsString }) => {
         globalStoreMock.user.currentRole = role;
-        const auth0State = { isAuthenticated: true };
+        const auth0State = { isAuthenticated: true, isLoading: false };
 
         useAppSelectorMock.mockImplementation((selector) => selector(globalStoreMock));
 
@@ -62,7 +62,7 @@ describe('App', () => {
         ${true}         | ${'calls check user registration on authenticated'}
         ${false}        | ${'does not call check user registration if user is not authenticated'}
     `('$friendlyName', (isAuthenticated) => {
-        const auth0State = { isAuthenticated };
+        const auth0State = { isAuthenticated, isLoading: false };
 
         const actionMock = {};
         checkUserRegistrationMock.mockReturnValueOnce(actionMock as AsyncThunkAction<WrappedUser | null | undefined, TokenAcquirer, never>);

--- a/www/src/App.test.tsx
+++ b/www/src/App.test.tsx
@@ -5,7 +5,7 @@ import { mocked } from 'ts-jest/utils';
 
 import App from './App';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
-import { RootState } from './redux/store';
+import { AppDispatch, RootState } from './redux/store';
 import checkUserRegistration from './redux/thunks/checkUserRegistration';
 import TokenAcquirer from './util/auth0/TokenAcquirer';
 import { WrappedUser } from './util/serverResponses';
@@ -29,10 +29,14 @@ jest.mock('react-router-dom', () => ({
 
 describe('App', () => {
     let globalStoreMock: RootState;
+    let dispatchMock: jest.MockedFunction<AppDispatch>;
 
     beforeEach(() => {
         setupIntersectionObserverMock();
         globalStoreMock = testConstants.globalStoreMock;
+
+        dispatchMock = jest.fn();
+        useAppDispatchMock.mockReturnValue(dispatchMock);
     });
 
     it.each`
@@ -42,9 +46,6 @@ describe('App', () => {
         ${'interviewer'} | ${'🚧 Work in progress 🚧'} | ${'an interviewer'}
         ${'admin'}       | ${'🚧 Work in progress 🚧'} | ${'an admin'}
     `('renders correctly for $friendlyName', ({ role, containsString }) => {
-        const dispatchMock = jest.fn();
-        useAppDispatchMock.mockReturnValue(dispatchMock);
-
         globalStoreMock.user.currentRole = role;
         const auth0State = { isAuthenticated: true };
 
@@ -61,9 +62,6 @@ describe('App', () => {
         ${true}         | ${'calls check user registration on authenticated'}
         ${false}        | ${'does not call check user registration if user is not authenticated'}
     `('$friendlyName', (isAuthenticated) => {
-        const dispatchMock = jest.fn();
-        useAppDispatchMock.mockReturnValue(dispatchMock);
-
         const auth0State = { isAuthenticated };
 
         const actionMock = {};

--- a/www/src/App.test.tsx
+++ b/www/src/App.test.tsx
@@ -28,15 +28,15 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('App', () => {
-    let globalStoreMock: RootState;
-    let dispatchMock: jest.MockedFunction<AppDispatch>;
+    let mockGlobalStore: RootState;
+    let mockDispatch: jest.MockedFunction<AppDispatch>;
 
     beforeEach(() => {
         setupIntersectionObserverMock();
-        globalStoreMock = testConstants.globalStoreMock;
+        mockGlobalStore = testConstants.globalStoreMock;
 
-        dispatchMock = jest.fn();
-        useAppDispatchMock.mockReturnValue(dispatchMock);
+        mockDispatch = jest.fn();
+        useAppDispatchMock.mockReturnValue(mockDispatch);
     });
 
     it.each`
@@ -46,10 +46,10 @@ describe('App', () => {
         ${'interviewer'} | ${'🚧 Work in progress 🚧'} | ${'an interviewer'}
         ${'admin'}       | ${'🚧 Work in progress 🚧'} | ${'an admin'}
     `('renders correctly for $friendlyName', ({ role, containsString }) => {
-        globalStoreMock.user.currentRole = role;
+        mockGlobalStore.user.currentRole = role;
         const auth0State = { isAuthenticated: true, isLoading: false };
 
-        useAppSelectorMock.mockImplementation((selector) => selector(globalStoreMock));
+        useAppSelectorMock.mockImplementation((selector) => selector(mockGlobalStore));
 
         render(withAuth0(<App />, auth0State));
 
@@ -67,14 +67,14 @@ describe('App', () => {
         const actionMock = {};
         checkUserRegistrationMock.mockReturnValueOnce(actionMock as AsyncThunkAction<WrappedUser | null | undefined, TokenAcquirer, never>);
 
-        useAppSelectorMock.mockImplementation((selector) => selector(globalStoreMock));
+        useAppSelectorMock.mockImplementation((selector) => selector(mockGlobalStore));
 
         render(withAuth0(<App />, auth0State));
 
         if (isAuthenticated) {
-            expect(dispatchMock).toBeCalledWith(actionMock);
+            expect(mockDispatch).toBeCalledWith(actionMock);
         } else {
-            expect(dispatchMock).not.toBeCalled();
+            expect(mockDispatch).not.toBeCalled();
         }
     });
 });

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -4,7 +4,7 @@ import React, { FC } from 'react';
 import { useEffect } from 'react';
 import { BrowserView, MobileView } from 'react-device-detect';
 import { Provider } from 'react-redux';
-import { BrowserRouter as Router, Redirect } from 'react-router-dom';
+import { BrowserRouter as Router, useHistory } from 'react-router-dom';
 
 import { Header, Section } from './components/Header';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
@@ -13,7 +13,6 @@ import volunteerStore from './redux/substores/volunteeer/volunteerStore';
 import checkUserRegistration from './redux/thunks/checkUserRegistration';
 import MobileLanding from './routes/MobileLanding';
 import StudentApp from './routes/Student';
-import Register from './routes/student/Register';
 import UnauthenticatedApp from './routes/Unauthenticated';
 import theme from './styles/theme';
 import { COMMUNITY, COMMUNITY_ROUTE, COMPE_PLUS, MOCK_INTERVIEW, MOCK_INTERVIEW_ROUTE, REGISTER_ROUTE, RESUME_REVIEW, RESUME_REVIEW_ROUTE } from './util/constants';
@@ -57,6 +56,8 @@ const getContentByRole = (role: string) => {
 };
 
 const App: FC = () => {
+    const history = useHistory();
+
     const currentRole = useAppSelector((state) => state.user.currentRole);
     const isUserRegistered = useAppSelector((state) => state.user.hasRegistered);
     const isLoadingUser = useAppSelector((state) => state.user.isLoading);
@@ -71,17 +72,17 @@ const App: FC = () => {
         }
     }, [isAuthenticated]);
 
+    if (!isLoadingUser && isUserRegistered === false) {
+        history.push(REGISTER_ROUTE);
+    }
+
     return (
         <ThemeProvider theme={theme}>
             <CssBaseline />
             <Container maxWidth={false} style={{ padding: 0, height: '100%' }}>
                 <Router>
                     <Header sections={header_sections} title={COMPE_PLUS} />
-                    <BrowserView renderWithFragment>
-                        <Register />
-                        {content}
-                        {!isLoadingUser && isUserRegistered === false && <Redirect to={REGISTER_ROUTE} />}
-                    </BrowserView>
+                    <BrowserView renderWithFragment>{content}</BrowserView>
                     <MobileView>
                         <MobileLanding />
                     </MobileView>

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -73,7 +73,7 @@ const App: FC = () => {
     return (
         <ThemeProvider theme={theme}>
             <CssBaseline />
-            <LoadingOverlay open={isLoading || isAuth0Loading || false} />
+            <LoadingOverlay open={isLoading || isAuth0Loading} />
             <Container maxWidth={false} style={{ padding: 0, height: '100%' }}>
                 <Router>
                     <Header sections={header_sections} title={COMPE_PLUS} />

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -57,11 +57,9 @@ const getContentByRole = (role: string) => {
 };
 
 const App: FC = () => {
-    const history = useHistory();
-
     const { isAuthenticated, getAccessTokenSilently, isLoading: isAuth0Loading } = useAuth0();
 
-    const { currentRole, hasRegistered, isLoading } = useAppSelector((state) => state.user);
+    const { currentRole, isLoading } = useAppSelector((state) => state.user);
     const dispatch = useAppDispatch();
 
     const content = getContentByRole(currentRole);
@@ -72,15 +70,10 @@ const App: FC = () => {
         }
     }, [isAuthenticated]);
 
-    if (hasRegistered === false) {
-        // Redirect to registration page if user hasn't registered
-        history.push(REGISTER_ROUTE);
-    }
-
     return (
         <ThemeProvider theme={theme}>
             <CssBaseline />
-            <LoadingOverlay open={isLoading || isAuth0Loading} />
+            <LoadingOverlay open={isLoading || isAuth0Loading || false} />
             <Container maxWidth={false} style={{ padding: 0, height: '100%' }}>
                 <Router>
                     <Header sections={header_sections} title={COMPE_PLUS} />

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import { BrowserRouter as Router, useHistory } from 'react-router-dom';
 
 import { Header, Section } from './components/Header';
+import LoadingOverlay from './components/LoadingOverlay';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
 import adminStore from './redux/substores/admin/adminStore';
 import volunteerStore from './redux/substores/volunteeer/volunteerStore';
@@ -58,12 +59,11 @@ const getContentByRole = (role: string) => {
 const App: FC = () => {
     const history = useHistory();
 
-    const currentRole = useAppSelector((state) => state.user.currentRole);
-    const isUserRegistered = useAppSelector((state) => state.user.hasRegistered);
-    const isLoadingUser = useAppSelector((state) => state.user.isLoading);
+    const { isAuthenticated, getAccessTokenSilently, isLoading: isAuth0Loading } = useAuth0();
 
-    const { isAuthenticated, getAccessTokenSilently } = useAuth0();
+    const { currentRole, hasRegistered, isLoading } = useAppSelector((state) => state.user);
     const dispatch = useAppDispatch();
+
     const content = getContentByRole(currentRole);
 
     useEffect(() => {
@@ -72,13 +72,15 @@ const App: FC = () => {
         }
     }, [isAuthenticated]);
 
-    if (!isLoadingUser && isUserRegistered === false) {
+    if (hasRegistered === false) {
+        // Redirect to registration page if user hasn't registered
         history.push(REGISTER_ROUTE);
     }
 
     return (
         <ThemeProvider theme={theme}>
             <CssBaseline />
+            <LoadingOverlay open={isLoading || isAuth0Loading} />
             <Container maxWidth={false} style={{ padding: 0, height: '100%' }}>
                 <Router>
                     <Header sections={header_sections} title={COMPE_PLUS} />

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -4,7 +4,7 @@ import React, { FC } from 'react';
 import { useEffect } from 'react';
 import { BrowserView, MobileView } from 'react-device-detect';
 import { Provider } from 'react-redux';
-import { BrowserRouter as Router, useHistory } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 import { Header, Section } from './components/Header';
 import LoadingOverlay from './components/LoadingOverlay';
@@ -16,7 +16,7 @@ import MobileLanding from './routes/MobileLanding';
 import StudentApp from './routes/Student';
 import UnauthenticatedApp from './routes/Unauthenticated';
 import theme from './styles/theme';
-import { COMMUNITY, COMMUNITY_ROUTE, COMPE_PLUS, MOCK_INTERVIEW, MOCK_INTERVIEW_ROUTE, REGISTER_ROUTE, RESUME_REVIEW, RESUME_REVIEW_ROUTE } from './util/constants';
+import { COMMUNITY, COMMUNITY_ROUTE, COMPE_PLUS, MOCK_INTERVIEW, MOCK_INTERVIEW_ROUTE, RESUME_REVIEW, RESUME_REVIEW_ROUTE } from './util/constants';
 
 const header_sections: Section[] = [
     { title: RESUME_REVIEW, url: RESUME_REVIEW_ROUTE },

--- a/www/src/components/LoadingOverlay.tsx
+++ b/www/src/components/LoadingOverlay.tsx
@@ -1,0 +1,27 @@
+import Backdrop from '@material-ui/core/Backdrop';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { makeStyles } from '@material-ui/core/styles';
+import React, { FC } from 'react';
+
+type LoadingOverlayProps = {
+    open: boolean;
+};
+
+const LoadingOverlay: FC<LoadingOverlayProps> = (props: LoadingOverlayProps) => {
+    const classes = useStyles();
+
+    return (
+        <Backdrop className={classes.backdrop} open={props.open}>
+            <CircularProgress color='inherit' />
+        </Backdrop>
+    );
+};
+
+const useStyles = makeStyles((theme) => ({
+    backdrop: {
+        zIndex: theme.zIndex.drawer + 1,
+        color: '#fff',
+    },
+}));
+
+export default LoadingOverlay;

--- a/www/src/redux/slices/registerUserSlice.ts
+++ b/www/src/redux/slices/registerUserSlice.ts
@@ -1,15 +1,17 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import registerUser, { UserInfo } from '../thunks/registerUser';
+import registerUser from '../thunks/registerUser';
 
 type RegisterUserState = {
-    userInfo: Partial<UserInfo>;
+    year: number;
+    program: string;
     registrationSuccess: boolean | null;
     isLoading: boolean;
 };
 
 const initialState: RegisterUserState = {
-    userInfo: {},
+    year: 0,
+    program: '',
     registrationSuccess: null,
     isLoading: false,
 };
@@ -18,14 +20,11 @@ export const registerUserSlice = createSlice({
     name: 'registerUser',
     initialState,
     reducers: {
-        initializeUserInfo(state, action: PayloadAction<Omit<UserInfo, 'year' | 'program'>>) {
-            state.userInfo = action.payload;
-        },
         setYear(state, action: PayloadAction<number>) {
-            state.userInfo.year = action.payload;
+            state.year = action.payload;
         },
         setProgram(state, action: PayloadAction<string>) {
-            state.userInfo.program = action.payload;
+            state.program = action.payload;
         },
     },
     extraReducers: (builder) => {
@@ -39,6 +38,6 @@ export const registerUserSlice = createSlice({
     },
 });
 
-export const { initializeUserInfo, setYear, setProgram } = registerUserSlice.actions;
+export const { setYear, setProgram } = registerUserSlice.actions;
 
 export default registerUserSlice.reducer;

--- a/www/src/redux/slices/registerUserSlice.ts
+++ b/www/src/redux/slices/registerUserSlice.ts
@@ -14,7 +14,7 @@ const initialState: RegisterUserState = {
     isLoading: false,
 };
 
-export const registerUserslice = createSlice({
+export const registerUserSlice = createSlice({
     name: 'registerUser',
     initialState,
     reducers: {
@@ -39,6 +39,6 @@ export const registerUserslice = createSlice({
     },
 });
 
-export const { initializeUserInfo, setYear, setProgram } = registerUserslice.actions;
+export const { initializeUserInfo, setYear, setProgram } = registerUserSlice.actions;
 
-export default registerUserslice.reducer;
+export default registerUserSlice.reducer;

--- a/www/src/redux/slices/registerUserSlice.ts
+++ b/www/src/redux/slices/registerUserSlice.ts
@@ -1,0 +1,44 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import registerUser, { UserInfo } from '../thunks/registerUser';
+
+type RegisterUserState = {
+    userInfo: Partial<UserInfo>;
+    registrationSuccess: boolean | null;
+    isLoading: boolean;
+};
+
+const initialState: RegisterUserState = {
+    userInfo: {},
+    registrationSuccess: null,
+    isLoading: false,
+};
+
+export const registerUserslice = createSlice({
+    name: 'registerUser',
+    initialState,
+    reducers: {
+        initializeUserInfo(state, action: PayloadAction<Omit<UserInfo, 'year' | 'program'>>) {
+            state.userInfo = action.payload;
+        },
+        setYear(state, action: PayloadAction<number>) {
+            state.userInfo.year = action.payload;
+        },
+        setProgram(state, action: PayloadAction<string>) {
+            state.userInfo.program = action.payload;
+        },
+    },
+    extraReducers: (builder) => {
+        builder.addCase(registerUser.pending, (state) => {
+            state.isLoading = true;
+        });
+        builder.addCase(registerUser.fulfilled, (state, action) => {
+            state.isLoading = false;
+            state.registrationSuccess = action.payload !== null;
+        });
+    },
+});
+
+export const { initializeUserInfo, setYear, setProgram } = registerUserslice.actions;
+
+export default registerUserslice.reducer;

--- a/www/src/redux/slices/userSlice.ts
+++ b/www/src/redux/slices/userSlice.ts
@@ -1,13 +1,12 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import checkUserRegistration from '../thunks/checkUserRegistration';
-import registerUser, { UserInfo } from '../thunks/registerUser';
+import registerUser from '../thunks/registerUser';
 
 type UserState = {
     roles: string[];
     currentRole: string;
     hasRegistered: boolean | null;
-    info: UserInfo | null;
     isEditRolesDialogOpen: boolean;
     isLoading: boolean;
 };
@@ -16,7 +15,6 @@ const initialState: UserState = {
     roles: [],
     currentRole: '',
     hasRegistered: null,
-    info: null,
     isEditRolesDialogOpen: false,
     isLoading: false,
 };

--- a/www/src/redux/slices/userSlice.ts
+++ b/www/src/redux/slices/userSlice.ts
@@ -1,7 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import checkUserRegistration from '../thunks/checkUserRegistration';
-import registerUser, { UserInfo } from '../thunks/registerUser';
 
 type UserState = {
     roles: string[];
@@ -9,7 +8,6 @@ type UserState = {
     hasRegistered: boolean | null;
     isEditRolesDialogOpen: boolean;
     isLoading: boolean;
-    info: UserInfo | null;
 };
 
 const initialState: UserState = {
@@ -18,7 +16,6 @@ const initialState: UserState = {
     hasRegistered: null,
     isEditRolesDialogOpen: false,
     isLoading: false,
-    info: null,
 };
 
 export const userSlice = createSlice({

--- a/www/src/redux/slices/userSlice.ts
+++ b/www/src/redux/slices/userSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import checkUserRegistration from '../thunks/checkUserRegistration';
-import registerUser from '../thunks/registerUser';
+import registerUser, { UserInfo } from '../thunks/registerUser';
 
 type UserState = {
     roles: string[];
@@ -9,6 +9,7 @@ type UserState = {
     hasRegistered: boolean | null;
     isEditRolesDialogOpen: boolean;
     isLoading: boolean;
+    info: UserInfo | null;
 };
 
 const initialState: UserState = {
@@ -17,6 +18,7 @@ const initialState: UserState = {
     hasRegistered: null,
     isEditRolesDialogOpen: false,
     isLoading: false,
+    info: null,
 };
 
 export const userSlice = createSlice({
@@ -34,18 +36,6 @@ export const userSlice = createSlice({
         },
     },
     extraReducers: (builder) => {
-        builder.addCase(registerUser.pending, (state) => {
-            state.isLoading = true;
-        });
-        builder.addCase(registerUser.fulfilled, (state, action) => {
-            const isSuccess = action.payload !== null;
-            if (isSuccess) {
-                state.hasRegistered = true;
-            } else {
-                // TODO: Display error message
-            }
-            state.isLoading = false;
-        });
         builder.addCase(checkUserRegistration.pending, (state) => {
             state.isLoading = true;
         });

--- a/www/src/redux/store.ts
+++ b/www/src/redux/store.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import registerUserReducer from './slices/registerUserSlice';
 import userReducer from './slices/userSlice';
 
 const store = configureStore({
     reducer: {
         user: userReducer,
+        registerUser: registerUserReducer,
     },
 });
 

--- a/www/src/routes/Unauthenticated.test.tsx
+++ b/www/src/routes/Unauthenticated.test.tsx
@@ -1,0 +1,46 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { mocked } from 'ts-jest/utils';
+
+import { useAppSelector } from '../redux/hooks';
+import { RootState } from '../redux/store';
+import { REGISTER_ROUTE } from '../util/constants';
+import testConstants from '../util/testConstants';
+import UnauthenticatedApp from './Unauthenticated';
+
+jest.mock('../redux/hooks');
+const useAppSelectorMock = mocked(useAppSelector, true);
+
+const mockHistoryPush = jest.fn();
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useHistory: () => ({
+        push: mockHistoryPush,
+    }),
+}));
+
+describe('Unauthenticated', () => {
+    let globalStoreMock: RootState;
+
+    beforeEach(() => {
+        globalStoreMock = testConstants.globalStoreMock;
+
+        useAppSelectorMock.mockImplementation((selector) => selector(globalStoreMock));
+    });
+
+    it('redirects to register page if the user has not registered', () => {
+        globalStoreMock.user.hasRegistered = false;
+
+        shallow(<UnauthenticatedApp />);
+
+        expect(mockHistoryPush).toBeCalledWith(REGISTER_ROUTE);
+    });
+
+    it('does not redirect if the user is registered', () => {
+        globalStoreMock.user.hasRegistered = true;
+
+        shallow(<UnauthenticatedApp />);
+
+        expect(mockHistoryPush).not.toBeCalledWith(REGISTER_ROUTE);
+    });
+});

--- a/www/src/routes/Unauthenticated.test.tsx
+++ b/www/src/routes/Unauthenticated.test.tsx
@@ -9,7 +9,7 @@ import testConstants from '../util/testConstants';
 import UnauthenticatedApp from './Unauthenticated';
 
 jest.mock('../redux/hooks');
-const useAppSelectorMock = mocked(useAppSelector, true);
+const mockUseAppSelector = mocked(useAppSelector, true);
 
 const mockHistoryPush = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -25,7 +25,7 @@ describe('Unauthenticated', () => {
     beforeEach(() => {
         globalStoreMock = testConstants.globalStoreMock;
 
-        useAppSelectorMock.mockImplementation((selector) => selector(globalStoreMock));
+        mockUseAppSelector.mockImplementation((selector) => selector(globalStoreMock));
     });
 
     it('redirects to register page if the user has not registered', () => {

--- a/www/src/routes/Unauthenticated.tsx
+++ b/www/src/routes/Unauthenticated.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Route, Switch, useHistory } from 'react-router-dom';
 
+import { useAppSelector } from '../redux/hooks';
 import { COMMUNITY_ROUTE, MOCK_INTERVIEW_ROUTE, REGISTER_ROUTE, RESUME_REVIEW_ROUTE } from '../util/constants';
 import Community from './Community';
 import Landing from './Landing';
@@ -9,6 +10,14 @@ import Register from './student/Register';
 import ResumeReview from './unauthenticated/ResumeReview';
 
 const UnauthenticatedApp: FC = () => {
+    const history = useHistory();
+
+    const { hasRegistered } = useAppSelector((state) => state.user);
+
+    if (hasRegistered === false) {
+        history.push(REGISTER_ROUTE);
+    }
+
     return (
         <Switch>
             <Route path={RESUME_REVIEW_ROUTE}>

--- a/www/src/routes/student/Register.tsx
+++ b/www/src/routes/student/Register.tsx
@@ -1,11 +1,46 @@
-import { Grid, Typography } from '@material-ui/core';
+import { useAuth0 } from '@auth0/auth0-react';
+import { Button, Grid, Typography } from '@material-ui/core';
 import React, { FC, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 
 import StyledSelect from '../../components/StyledSelect';
+import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import registerUser from '../../redux/thunks/registerUser';
 
 const Registration: FC = () => {
+    const history = useHistory();
+
     const [year, setYear] = useState('');
     const [speciality, setSpeciality] = useState('');
+
+    const { user, getAccessTokenSilently } = useAuth0();
+
+    const { hasRegistered } = useAppSelector((state) => state.user);
+    const dispatch = useAppDispatch();
+
+    if (hasRegistered) {
+        // Redirect back to home once register finishes
+        history.replace('/');
+    }
+
+    const handleRegisterUser = () => {
+        dispatch(
+            registerUser({
+                tokenAcquirer: getAccessTokenSilently,
+                userInfo: {
+                    ccid: user?.email?.split('@')[0] ?? '',
+                    email: user?.email ?? '',
+                    familyName: user?.family_name ?? '',
+                    fullName: user?.name ?? '',
+                    givenName: user?.given_name ?? '',
+                    id: user?.sub ?? '',
+                    program: speciality,
+                    year: parseInt(year),
+                },
+            }),
+        );
+    };
+
     return (
         <div style={{ overflow: 'hidden' }}>
             <Grid container justify='center' alignItems='center' spacing={8} style={{ marginTop: '10px', minHeight: '75vh' }}>
@@ -23,6 +58,7 @@ const Registration: FC = () => {
                                 onChange={setSpeciality}
                                 choices={['Computer Co-op', 'Software Co-op', 'Nano Co-op', 'Computer Trad', 'Nano Trad', ' Other']}
                             />
+                            <Button onClick={handleRegisterUser}>Submit</Button>
                         </form>
                     </Grid>
                 </Grid>
@@ -30,4 +66,5 @@ const Registration: FC = () => {
         </div>
     );
 };
+
 export default Registration;

--- a/www/src/routes/student/Register.tsx
+++ b/www/src/routes/student/Register.tsx
@@ -1,14 +1,14 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { Button, Grid, Typography } from '@material-ui/core';
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import LoadingOverlay from '../../components/LoadingOverlay';
 import StyledSelect from '../../components/StyledSelect';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
-import { initializeUserInfo, setProgram, setYear } from '../../redux/slices/registerUserSlice';
+import { setProgram, setYear } from '../../redux/slices/registerUserSlice';
 import checkUserRegistration from '../../redux/thunks/checkUserRegistration';
-import registerUser, { UserInfo } from '../../redux/thunks/registerUser';
+import registerUser from '../../redux/thunks/registerUser';
 
 const Registration: FC = () => {
     const history = useHistory();
@@ -16,7 +16,7 @@ const Registration: FC = () => {
     const { user, getAccessTokenSilently } = useAuth0();
 
     const { hasRegistered } = useAppSelector((state) => state.user);
-    const { userInfo, isLoading } = useAppSelector((state) => state.registerUser);
+    const { year, program, isLoading } = useAppSelector((state) => state.registerUser);
 
     const dispatch = useAppDispatch();
 
@@ -27,7 +27,7 @@ const Registration: FC = () => {
     }
 
     const handleRegisterUser = () => {
-        if (userInfo === null || userInfo.year === undefined || userInfo.program === undefined) {
+        if (year <= 0 || program === '' || user === undefined) {
             alert('Form is incomplete, please complete the form');
             return;
         }
@@ -35,23 +35,19 @@ const Registration: FC = () => {
         dispatch(
             registerUser({
                 tokenAcquirer: getAccessTokenSilently,
-                userInfo: userInfo as UserInfo,
+                userInfo: {
+                    ccid: user.email?.split('@')[0] ?? '',
+                    email: user.email ?? '',
+                    familyName: user.family_name ?? '',
+                    fullName: user?.name ?? '',
+                    givenName: user?.given_name ?? '',
+                    id: user?.sub ?? '',
+                    year,
+                    program,
+                },
             }),
         );
     };
-
-    useEffect(() => {
-        dispatch(
-            initializeUserInfo({
-                ccid: user?.email?.split('@')[0] ?? '',
-                email: user?.email ?? '',
-                familyName: user?.family_name ?? '',
-                fullName: user?.name ?? '',
-                givenName: user?.given_name ?? '',
-                id: user?.sub ?? '',
-            }),
-        );
-    }, [user, dispatch]);
 
     const yearChoices = ['1', '2', '3', '4', '5', '6+'];
     const programChoices = ['Computer Co-op', 'Software Co-op', 'Nano Co-op', 'Computer Trad', 'Nano Trad', ' Other'];
@@ -67,8 +63,8 @@ const Registration: FC = () => {
                 <Grid container item spacing={4}>
                     <Grid container item xs={12} justify='center'>
                         <form>
-                            <StyledSelect title='Year' value={userInfo?.year?.toString() ?? ''} onChange={(newYear) => dispatch(setYear(parseInt(newYear)))} choices={yearChoices} />
-                            <StyledSelect title='Speciality' value={userInfo?.program ?? ''} onChange={(newProgram) => dispatch(setProgram(newProgram))} choices={programChoices} />
+                            <StyledSelect title='Year' value={year.toString()} onChange={(newYear) => dispatch(setYear(parseInt(newYear)))} choices={yearChoices} />
+                            <StyledSelect title='Speciality' value={program} onChange={(newProgram) => dispatch(setProgram(newProgram))} choices={programChoices} />
                             <Button onClick={handleRegisterUser}>Submit</Button>
                         </form>
                     </Grid>

--- a/www/src/routes/student/Register.tsx
+++ b/www/src/routes/student/Register.tsx
@@ -7,14 +7,16 @@ import StyledSelect from '../../components/StyledSelect';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { initializeUserInfo, setProgram, setYear } from '../../redux/slices/registerUserSlice';
 import checkUserRegistration from '../../redux/thunks/checkUserRegistration';
-import registerUser from '../../redux/thunks/registerUser';
+import registerUser, { UserInfo } from '../../redux/thunks/registerUser';
 
 const Registration: FC = () => {
     const history = useHistory();
 
     const { user, getAccessTokenSilently } = useAuth0();
 
-    const { hasRegistered, info } = useAppSelector((state) => state.user);
+    const { hasRegistered } = useAppSelector((state) => state.user);
+    const { userInfo } = useAppSelector((state) => state.registerUser);
+
     const dispatch = useAppDispatch();
 
     // Redirect back to home once register finishes
@@ -24,7 +26,7 @@ const Registration: FC = () => {
     }
 
     const handleRegisterUser = () => {
-        if (info === null || info.year === undefined || info.program === undefined) {
+        if (userInfo === null || userInfo.year === undefined || userInfo.program === undefined) {
             alert('Form is incomplete, please complete the form');
             return;
         }
@@ -32,7 +34,7 @@ const Registration: FC = () => {
         dispatch(
             registerUser({
                 tokenAcquirer: getAccessTokenSilently,
-                userInfo: info,
+                userInfo: userInfo as UserInfo,
             }),
         );
     };
@@ -48,7 +50,7 @@ const Registration: FC = () => {
                 id: user?.sub ?? '',
             }),
         );
-    }, []);
+    }, [user, dispatch]);
 
     const yearChoices = ['1', '2', '3', '4', '5', '6+'];
     const programChoices = ['Computer Co-op', 'Software Co-op', 'Nano Co-op', 'Computer Trad', 'Nano Trad', ' Other'];
@@ -63,8 +65,8 @@ const Registration: FC = () => {
                 <Grid container item spacing={4}>
                     <Grid container item xs={12} justify='center'>
                         <form>
-                            <StyledSelect title='Year' value={info?.year.toString() ?? ''} onChange={(newYear) => dispatch(setYear(parseInt(newYear)))} choices={yearChoices} />
-                            <StyledSelect title='Speciality' value={info?.program ?? ''} onChange={(newProgram) => dispatch(setProgram(newProgram))} choices={programChoices} />
+                            <StyledSelect title='Year' value={userInfo?.year?.toString() ?? ''} onChange={(newYear) => dispatch(setYear(parseInt(newYear)))} choices={yearChoices} />
+                            <StyledSelect title='Speciality' value={userInfo?.program ?? ''} onChange={(newProgram) => dispatch(setProgram(newProgram))} choices={programChoices} />
                             <Button onClick={handleRegisterUser}>Submit</Button>
                         </form>
                     </Grid>

--- a/www/src/routes/student/Register.tsx
+++ b/www/src/routes/student/Register.tsx
@@ -50,7 +50,7 @@ const Registration: FC = () => {
         );
     }, []);
 
-    const yearChoices = ['1', '2', '3', '4', '5', '5+'];
+    const yearChoices = ['1', '2', '3', '4', '5', '6+'];
     const programChoices = ['Computer Co-op', 'Software Co-op', 'Nano Co-op', 'Computer Trad', 'Nano Trad', ' Other'];
 
     return (

--- a/www/src/routes/student/Register.tsx
+++ b/www/src/routes/student/Register.tsx
@@ -3,6 +3,7 @@ import { Button, Grid, Typography } from '@material-ui/core';
 import React, { FC, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
+import LoadingOverlay from '../../components/LoadingOverlay';
 import StyledSelect from '../../components/StyledSelect';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { initializeUserInfo, setProgram, setYear } from '../../redux/slices/registerUserSlice';
@@ -15,7 +16,7 @@ const Registration: FC = () => {
     const { user, getAccessTokenSilently } = useAuth0();
 
     const { hasRegistered } = useAppSelector((state) => state.user);
-    const { userInfo } = useAppSelector((state) => state.registerUser);
+    const { userInfo, isLoading } = useAppSelector((state) => state.registerUser);
 
     const dispatch = useAppDispatch();
 
@@ -57,6 +58,7 @@ const Registration: FC = () => {
 
     return (
         <div style={{ overflow: 'hidden' }}>
+            <LoadingOverlay open={isLoading} />
             <Grid container justify='center' alignItems='center' spacing={8} style={{ marginTop: '10px', minHeight: '75vh' }}>
                 <Grid container item justify='center'>
                     <Typography variant='h1'>Registration</Typography>

--- a/www/src/routes/student/Register.tsx
+++ b/www/src/routes/student/Register.tsx
@@ -17,8 +17,8 @@ const Registration: FC = () => {
     const { hasRegistered, info } = useAppSelector((state) => state.user);
     const dispatch = useAppDispatch();
 
+    // Redirect back to home once register finishes
     if (hasRegistered) {
-        // Redirect back to home once register finishes
         dispatch(checkUserRegistration(getAccessTokenSilently));
         history.replace('/');
     }

--- a/www/src/routes/student/Register.tsx
+++ b/www/src/routes/student/Register.tsx
@@ -1,45 +1,57 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { Button, Grid, Typography } from '@material-ui/core';
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import StyledSelect from '../../components/StyledSelect';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { initializeUserInfo, setProgram, setYear } from '../../redux/slices/registerUserSlice';
+import checkUserRegistration from '../../redux/thunks/checkUserRegistration';
 import registerUser from '../../redux/thunks/registerUser';
 
 const Registration: FC = () => {
     const history = useHistory();
 
-    const [year, setYear] = useState('');
-    const [speciality, setSpeciality] = useState('');
-
     const { user, getAccessTokenSilently } = useAuth0();
 
-    const { hasRegistered } = useAppSelector((state) => state.user);
+    const { hasRegistered, info } = useAppSelector((state) => state.user);
     const dispatch = useAppDispatch();
 
     if (hasRegistered) {
         // Redirect back to home once register finishes
+        dispatch(checkUserRegistration(getAccessTokenSilently));
         history.replace('/');
     }
 
     const handleRegisterUser = () => {
+        if (info === null || info.year === undefined || info.program === undefined) {
+            alert('Form is incomplete, please complete the form');
+            return;
+        }
+
         dispatch(
             registerUser({
                 tokenAcquirer: getAccessTokenSilently,
-                userInfo: {
-                    ccid: user?.email?.split('@')[0] ?? '',
-                    email: user?.email ?? '',
-                    familyName: user?.family_name ?? '',
-                    fullName: user?.name ?? '',
-                    givenName: user?.given_name ?? '',
-                    id: user?.sub ?? '',
-                    program: speciality,
-                    year: parseInt(year),
-                },
+                userInfo: info,
             }),
         );
     };
+
+    useEffect(() => {
+        dispatch(
+            initializeUserInfo({
+                ccid: user?.email?.split('@')[0] ?? '',
+                email: user?.email ?? '',
+                familyName: user?.family_name ?? '',
+                fullName: user?.name ?? '',
+                givenName: user?.given_name ?? '',
+                id: user?.sub ?? '',
+            }),
+        );
+    }, []);
+
+    const yearChoices = ['1', '2', '3', '4', '5', '5+'];
+    const programChoices = ['Computer Co-op', 'Software Co-op', 'Nano Co-op', 'Computer Trad', 'Nano Trad', ' Other'];
 
     return (
         <div style={{ overflow: 'hidden' }}>
@@ -51,13 +63,8 @@ const Registration: FC = () => {
                 <Grid container item spacing={4}>
                     <Grid container item xs={12} justify='center'>
                         <form>
-                            <StyledSelect title='Year' value={year} onChange={setYear} choices={['1', '2', '3', '4', '5', '5+']} />
-                            <StyledSelect
-                                title='Speciality'
-                                value={speciality}
-                                onChange={setSpeciality}
-                                choices={['Computer Co-op', 'Software Co-op', 'Nano Co-op', 'Computer Trad', 'Nano Trad', ' Other']}
-                            />
+                            <StyledSelect title='Year' value={info?.year.toString() ?? ''} onChange={(newYear) => dispatch(setYear(parseInt(newYear)))} choices={yearChoices} />
+                            <StyledSelect title='Speciality' value={info?.program ?? ''} onChange={(newProgram) => dispatch(setProgram(newProgram))} choices={programChoices} />
                             <Button onClick={handleRegisterUser}>Submit</Button>
                         </form>
                     </Grid>

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -43,7 +43,8 @@ const globalStoreMock: RootState = {
         isEditRolesDialogOpen: false,
     },
     registerUser: {
-        userInfo: {},
+        year: 0,
+        program: '',
         registrationSuccess: null,
         isLoading: false,
     },

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -42,6 +42,11 @@ const globalStoreMock: RootState = {
         hasRegistered: true,
         isEditRolesDialogOpen: false,
     },
+    registerUser: {
+        userInfo: {},
+        registrationSuccess: null,
+        isLoading: false,
+    },
 };
 
 export default { user1, resumeReview1, document1, globalStoreMock };

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -1,3 +1,4 @@
+import { RootState } from '../redux/store';
 import { Document, ResumeReview, User } from './serverResponses';
 
 const user1: User = {
@@ -33,4 +34,14 @@ const document1: Document = {
     updatedAt: '2021-06-14T06:09:19.373404+00:00',
 };
 
-export default { user1, resumeReview1, document1 };
+const globalStoreMock: RootState = {
+    user: {
+        roles: [],
+        currentRole: '',
+        isLoading: false,
+        hasRegistered: true,
+        isEditRolesDialogOpen: false,
+    },
+};
+
+export default { user1, resumeReview1, document1, globalStoreMock };


### PR DESCRIPTION
# Overview

* Allow developers to register themselves without manually posting to the backend
* Prevent users from double registering by redirecting users back to the home page from the register page

# Changes

* Move form state to redux
* Add submit button in register page
* Move redirect to register page to unauthenticated app
* Cleaned up tests in App.tsx
* Fix missing `.end()` call in backend that results a 200 code even when user doesn't exist
* Add loading overlays when auth0 is loading or we're fetching the backedn

# Questions & Notes

* Styling will be handled in a separate PR by @AnushkaKhare-Eng 

# Issue tracking

Closes #107

# Testing & Demo

Refer to unit tests