### PR TITLE
Use https for local front end dev

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -5,9 +5,9 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 ## Authentication set-up
 
 1. Copy `www/.env.sample` to `www/.env`
-2. Using the `compe-plus-dev` tenant in ![Auth0](https://manage.auth0.com/dashboard), expand _Applications_ on the left sidebar and click on _Compe+ Web Application_
+2. Using the `compe-plus-dev` tenant in [Auth0](https://manage.auth0.com/dashboard), expand _Applications_ on the left sidebar and click on _Compe+ Web Application_
 3. In the settings page, copy the domain and client ID to their respective fields in the `.env` file
-4. Copy the non-localhost _Allowed Callback URLs_ to `/etc/hosts` as follows
+4. Copy the non-localhost _Allowed Callback URL_ to `/etc/hosts` as follows
     ```
     127.0.0.1     <NON_LOCALHOST_CALLBACK_URL_HERE>
     ```

--- a/www/README.md
+++ b/www/README.md
@@ -5,8 +5,12 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 ## Authentication set-up
 
 1. Copy `www/.env.sample` to `www/.env`
-2. Navigate to `compe-plus` application in ![Auth0](https://manage.auth0.com/dashboard)
+2. Using the `compe-plus-dev` tenant in ![Auth0](https://manage.auth0.com/dashboard), expand _Applications_ on the left sidebar and click on _Compe+ Web Application_
 3. In the settings page, copy the domain and client ID to their respective fields in the `.env` file
+4. Copy the non-localhost _Allowed Callback URLs_ to `/etc/hosts` as follows
+    ```
+    127.0.0.1     <NON_LOCALHOST_CALLBACK_URL_HERE>
+    ```
 
 ## Available Scripts
 
@@ -15,7 +19,7 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Open [https://<NON_LOCALHOST_CALLBACK_URL_HERE>:3000](https://<NON_LOCALHOST_CALLBACK_URL_HERE>:3000) to view it in the browser.
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.

--- a/www/package.json
+++ b/www/package.json
@@ -33,7 +33,7 @@
         "web-vitals": "^1.1.2"
     },
     "scripts": {
-        "start": "react-scripts start",
+        "start": "HTTPS=true react-scripts start",
         "build": "react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject",


### PR DESCRIPTION
# Overview

* Allows devs to fetch token with scopes without user consent (mimics how staging and prod behaves)

# Changes

* Use https port to serve local front end
* Add instructions on how to add new non-localhost mapping to `/etc/hosts`

# Questions & Notes

* Auth0 doesn't allow [skipping user consent for apps hosted in localhost](https://auth0.com/docs/authorization/user-consent-and-third-party-applications#skip-consent-for-first-party-applications). A dev fix for this would require us to make localhost behave as if it was hosted elsewhere
* Adding a new entry in `/etc/hosts` allows our machine to "host" on a domain other than "localhost"
* Actual non-localhost URL isn't added to prevent anyone from cloning this repository and messing up our dev environment (Auth0's original intention)

# Issue tracking


# Testing & Demo

Token fetches without prior consent from developers should no longer fail 