### PR TITLE
Integrate role switches to views

### DIFF
--- a/www/src/App.test.tsx
+++ b/www/src/App.test.tsx
@@ -72,11 +72,10 @@ describe('App', () => {
     });
 
     it.each`
-        role             | friendlyName
-        ${'student'}     | ${'a student'}
-        ${'reviewer'}    | ${'a reviewer'}
-        ${'interviewer'} | ${'an interviewer'}
-        ${'admin'}       | ${'an admin'}
+        role           | friendlyName
+        ${'student'}   | ${'a student'}
+        ${'volunteer'} | ${'a reviewer/interviewer'}
+        ${'admin'}     | ${'an admin'}
     `('renders Landing by default for $friendlyName', ({ role }) => {
         mockGlobalStore.user.currentRole = role;
 

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -7,7 +7,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 
 import { Header, Section } from './components/Header';
 import LoadingOverlay from './components/LoadingOverlay';
-import EditRolesDialog from './components/user/EditRolesDialog';
+import SettingsDialoog from './components/user/SettingsDialog';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
 import checkUserRegistration from './redux/thunks/checkUserRegistration';
 import getUserRole from './redux/thunks/getUserRole';
@@ -68,7 +68,7 @@ const App: FC = () => {
                     <Header sections={header_sections} title={COMPE_PLUS} />
                     <BrowserView renderWithFragment>
                         {content}
-                        <EditRolesDialog />
+                        <SettingsDialoog />
                     </BrowserView>
                     <MobileView>
                         <MobileLanding />

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -29,8 +29,7 @@ const getContentByRole = (role: string) => {
     switch (role) {
         case 'admin':
             return <AdminApp />;
-        case 'reviewer':
-        case 'interviewer':
+        case 'volunteer':
             return <VolunteerApp />;
         case 'student':
             return <StudentApp />;

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -7,7 +7,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 
 import { Header, Section } from './components/Header';
 import LoadingOverlay from './components/LoadingOverlay';
-import SettingsDialoog from './components/user/SettingsDialog';
+import SettingsDialog from './components/user/SettingsDialog';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
 import checkUserRegistration from './redux/thunks/checkUserRegistration';
 import getUserRole from './redux/thunks/getUserRole';
@@ -68,7 +68,7 @@ const App: FC = () => {
                     <Header sections={header_sections} title={COMPE_PLUS} />
                     <BrowserView renderWithFragment>
                         {content}
-                        <SettingsDialoog />
+                        <SettingsDialog />
                     </BrowserView>
                     <MobileView>
                         <MobileLanding />

--- a/www/src/components/user/EditRolesDialog.tsx
+++ b/www/src/components/user/EditRolesDialog.tsx
@@ -1,6 +1,4 @@
-import { DialogContent } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core';
-import { DialogContentText } from '@material-ui/core';
+import { DialogContent, FormControlLabel, FormGroup } from '@material-ui/core';
 import { Switch } from '@material-ui/core';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -8,31 +6,57 @@ import React, { FC } from 'react';
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { closeEditRolesDialog, setCurrentRole } from '../../redux/slices/userSlice';
-import theme from '../../styles/theme';
 
 const EditRolesDialog: FC = () => {
     const dispatch = useAppDispatch();
 
-    const { isEditRolesDialogOpen, currentRole } = useAppSelector((state) => state.user);
-
-    const classes = useStyles();
+    const { isEditRolesDialogOpen, currentRole, roles } = useAppSelector((state) => state.user);
 
     return (
         <Dialog onClose={() => dispatch(closeEditRolesDialog())} open={isEditRolesDialogOpen}>
             <DialogTitle>Edit Roles</DialogTitle>
             <DialogContent>
-                <DialogContentText className={classes.dialog_content}>Resume Reviewer</DialogContentText>
+                <FormGroup row>
+                    <FormControlLabel
+                        labelPlacement='start'
+                        control={
+                            <Switch
+                                checked={currentRole === 'student'}
+                                onChange={() => dispatch(setCurrentRole('student'))}
+                                inputProps={{ 'aria-label': 'Toggle student role' }}
+                                disabled={!roles.includes('student')}
+                            />
+                        }
+                        label='Student'
+                    />
+                    <FormControlLabel
+                        labelPlacement='start'
+                        control={
+                            <Switch
+                                checked={currentRole === 'volunteer'}
+                                onChange={() => dispatch(setCurrentRole('volunteer'))}
+                                inputProps={{ 'aria-label': 'Toggle volunteer role' }}
+                                disabled={!roles.includes('reviewer' || !roles.includes('interviewer'))}
+                            />
+                        }
+                        label='Volunteer'
+                    />
+                    <FormControlLabel
+                        labelPlacement='start'
+                        control={
+                            <Switch
+                                checked={currentRole === 'admin'}
+                                onChange={() => dispatch(setCurrentRole('admin'))}
+                                inputProps={{ 'aria-label': 'Toggle admin role' }}
+                                disabled={!roles.includes('admin')}
+                            />
+                        }
+                        label='Admin'
+                    />
+                </FormGroup>
             </DialogContent>
-            <Switch checked={currentRole === 'student'} onChange={() => dispatch(setCurrentRole('student'))} inputProps={{ 'aria-label': 'Toggle student role' }} />
-            <DialogContent>
-                <DialogContentText className={classes.dialog_content}>Interviwer</DialogContentText>
-            </DialogContent>
-            <Switch checked={currentRole === 'volunteer'} onChange={() => dispatch(setCurrentRole('volunteer'))} inputProps={{ 'aria-label': 'Toggle volunteer role' }} />
         </Dialog>
     );
 };
-const useStyles = makeStyles(() => ({
-    dialog_content: { color: theme.palette.text.primary },
-}));
 
 export default EditRolesDialog;

--- a/www/src/components/user/SettingsDialog.test.tsx
+++ b/www/src/components/user/SettingsDialog.test.tsx
@@ -6,7 +6,7 @@ import { mocked } from 'ts-jest/utils';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
 import testConstants from '../../util/testConstants';
-import EditRolesDialog from './EditRolesDialog';
+import SettingsDialoog from './SettingsDialog';
 
 jest.mock('../../redux/hooks');
 
@@ -28,7 +28,7 @@ describe('EditRolesDialog', () => {
         mockGlobalStore.user.isEditRolesDialogOpen = isEditRolesDialogOpen;
         mockUseAppSelector.mockImplementation((selector) => selector(mockGlobalStore));
 
-        const result = shallow(<EditRolesDialog />);
+        const result = shallow(<SettingsDialoog />);
 
         const dialog = result.find(Dialog);
         expect(dialog.props()['open']).toBe(isEditRolesDialogOpen);
@@ -38,7 +38,7 @@ describe('EditRolesDialog', () => {
         mockGlobalStore.user.currentRole = currentRole;
         mockUseAppSelector.mockImplementation((selector) => selector(mockGlobalStore));
 
-        const result = shallow(<EditRolesDialog />);
+        const result = shallow(<SettingsDialoog />);
 
         // TODO: Update selector once UI has been refactored to use keys
         const roleSwitch = result.find({ inputProps: { 'aria-label': `Toggle ${currentRole} role` } });

--- a/www/src/components/user/SettingsDialog.test.tsx
+++ b/www/src/components/user/SettingsDialog.test.tsx
@@ -16,7 +16,7 @@ const mockDispatch = jest.fn();
 
 mockUseAppDispatch.mockReturnValue(mockDispatch);
 
-describe('EditRolesDialog', () => {
+describe('Settings', () => {
     let mockGlobalStore: RootState;
     beforeEach(() => {
         mockGlobalStore = testConstants.globalState;
@@ -25,7 +25,7 @@ describe('EditRolesDialog', () => {
     });
 
     it.each([true, false])('gets the proper dialog state from redux state', (isEditRolesDialogOpen) => {
-        mockGlobalStore.user.isEditRolesDialogOpen = isEditRolesDialogOpen;
+        mockGlobalStore.user.isSettingsDialogOpen = isEditRolesDialogOpen;
         mockUseAppSelector.mockImplementation((selector) => selector(mockGlobalStore));
 
         const result = shallow(<SettingsDialog />);
@@ -40,7 +40,6 @@ describe('EditRolesDialog', () => {
 
         const result = shallow(<SettingsDialog />);
 
-        // TODO: Update selector once UI has been refactored to use keys
         const roleSwitch = result.find({ inputProps: { 'aria-label': `Toggle ${currentRole} role` } });
         expect(roleSwitch.props()['checked']).toBe(true);
     });

--- a/www/src/components/user/SettingsDialog.test.tsx
+++ b/www/src/components/user/SettingsDialog.test.tsx
@@ -6,7 +6,7 @@ import { mocked } from 'ts-jest/utils';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
 import testConstants from '../../util/testConstants';
-import SettingsDialoog from './SettingsDialog';
+import SettingsDialog from './SettingsDialog';
 
 jest.mock('../../redux/hooks');
 
@@ -28,7 +28,7 @@ describe('EditRolesDialog', () => {
         mockGlobalStore.user.isEditRolesDialogOpen = isEditRolesDialogOpen;
         mockUseAppSelector.mockImplementation((selector) => selector(mockGlobalStore));
 
-        const result = shallow(<SettingsDialoog />);
+        const result = shallow(<SettingsDialog />);
 
         const dialog = result.find(Dialog);
         expect(dialog.props()['open']).toBe(isEditRolesDialogOpen);
@@ -38,7 +38,7 @@ describe('EditRolesDialog', () => {
         mockGlobalStore.user.currentRole = currentRole;
         mockUseAppSelector.mockImplementation((selector) => selector(mockGlobalStore));
 
-        const result = shallow(<SettingsDialoog />);
+        const result = shallow(<SettingsDialog />);
 
         // TODO: Update selector once UI has been refactored to use keys
         const roleSwitch = result.find({ inputProps: { 'aria-label': `Toggle ${currentRole} role` } });

--- a/www/src/components/user/SettingsDialog.test.tsx
+++ b/www/src/components/user/SettingsDialog.test.tsx
@@ -24,23 +24,43 @@ describe('Settings', () => {
         mockUseAppSelector.mockImplementation((selector) => selector(mockGlobalStore));
     });
 
-    it.each([true, false])('gets the proper dialog state from redux state', (isEditRolesDialogOpen) => {
-        mockGlobalStore.user.isSettingsDialogOpen = isEditRolesDialogOpen;
+    it.each([true, false])('gets the proper dialog state from redux state', (isSettingsDialogOpen) => {
+        mockGlobalStore.user.isSettingsDialogOpen = isSettingsDialogOpen;
         mockUseAppSelector.mockImplementation((selector) => selector(mockGlobalStore));
 
         const result = shallow(<SettingsDialog />);
 
         const dialog = result.find(Dialog);
-        expect(dialog.props()['open']).toBe(isEditRolesDialogOpen);
+        expect(dialog.props()['open']).toBe(isSettingsDialogOpen);
     });
 
-    it.each(['student', 'volunteer'])('gets the proper user role from redux state', (currentRole) => {
+    it.each(['student', 'volunteer', 'admin'])('gets the proper user role from redux state', (currentRole) => {
         mockGlobalStore.user.currentRole = currentRole;
         mockUseAppSelector.mockImplementation((selector) => selector(mockGlobalStore));
 
         const result = shallow(<SettingsDialog />);
 
-        const roleSwitch = result.find({ inputProps: { 'aria-label': `Toggle ${currentRole} role` } });
-        expect(roleSwitch.props()['checked']).toBe(true);
+        const roleToLabelMap = new Map([
+            ['student', 'Student'],
+            ['volunteer', 'Volunteer'],
+            ['admin', 'Admin'],
+        ]);
+
+        const roleSwitch = result.find({ label: roleToLabelMap.get(currentRole) });
+        expect(roleSwitch.prop('control').props['checked']).toBe(true);
+    });
+
+    it('disables the reviewer and admin switches if user is a student', () => {
+        mockGlobalStore.user.currentRole = 'student';
+        mockGlobalStore.user.roles = ['student'];
+        mockUseAppSelector.mockImplementation((selector) => selector(mockGlobalStore));
+
+        const result = shallow(<SettingsDialog />);
+
+        const volunteerSwitch = result.find({ label: 'Volunteer' });
+        expect(volunteerSwitch.prop('control').props['disabled']).toBe(true);
+
+        const adminSwitch = result.find({ label: 'Admin' });
+        expect(adminSwitch.prop('control').props['disabled']).toBe(true);
     });
 });

--- a/www/src/components/user/SettingsDialog.tsx
+++ b/www/src/components/user/SettingsDialog.tsx
@@ -7,7 +7,7 @@ import React, { FC } from 'react';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { closeEditRolesDialog, setCurrentRole } from '../../redux/slices/userSlice';
 
-const SettingsDialoog: FC = () => {
+const SettingsDialog: FC = () => {
     const dispatch = useAppDispatch();
 
     const { isEditRolesDialogOpen, currentRole, roles } = useAppSelector((state) => state.user);
@@ -59,4 +59,4 @@ const SettingsDialoog: FC = () => {
     );
 };
 
-export default SettingsDialoog;
+export default SettingsDialog;

--- a/www/src/components/user/SettingsDialog.tsx
+++ b/www/src/components/user/SettingsDialog.tsx
@@ -10,10 +10,10 @@ import { closeEditRolesDialog, setCurrentRole } from '../../redux/slices/userSli
 const SettingsDialog: FC = () => {
     const dispatch = useAppDispatch();
 
-    const { isEditRolesDialogOpen, currentRole, roles } = useAppSelector((state) => state.user);
+    const { isSettingsDialogOpen, currentRole, roles } = useAppSelector((state) => state.user);
 
     return (
-        <Dialog onClose={() => dispatch(closeEditRolesDialog())} open={isEditRolesDialogOpen}>
+        <Dialog onClose={() => dispatch(closeEditRolesDialog())} open={isSettingsDialogOpen}>
             <DialogTitle>Settings</DialogTitle>
             <DialogContent>
                 <FormGroup row>

--- a/www/src/components/user/SettingsDialog.tsx
+++ b/www/src/components/user/SettingsDialog.tsx
@@ -7,14 +7,14 @@ import React, { FC } from 'react';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { closeEditRolesDialog, setCurrentRole } from '../../redux/slices/userSlice';
 
-const EditRolesDialog: FC = () => {
+const SettingsDialoog: FC = () => {
     const dispatch = useAppDispatch();
 
     const { isEditRolesDialogOpen, currentRole, roles } = useAppSelector((state) => state.user);
 
     return (
         <Dialog onClose={() => dispatch(closeEditRolesDialog())} open={isEditRolesDialogOpen}>
-            <DialogTitle>Edit Roles</DialogTitle>
+            <DialogTitle>Settings</DialogTitle>
             <DialogContent>
                 <FormGroup row>
                     <FormControlLabel
@@ -59,4 +59,4 @@ const EditRolesDialog: FC = () => {
     );
 };
 
-export default EditRolesDialog;
+export default SettingsDialoog;

--- a/www/src/redux/slices/userSlice.ts
+++ b/www/src/redux/slices/userSlice.ts
@@ -7,7 +7,7 @@ type UserState = {
     roles: string[];
     currentRole: string;
     hasRegistered: boolean | null;
-    isEditRolesDialogOpen: boolean;
+    isSettingsDialogOpen: boolean;
     isLoading: boolean;
 };
 
@@ -15,7 +15,7 @@ const initialState: UserState = {
     roles: [],
     currentRole: '',
     hasRegistered: null,
-    isEditRolesDialogOpen: false,
+    isSettingsDialogOpen: false,
     isLoading: false,
 };
 
@@ -27,10 +27,10 @@ export const userSlice = createSlice({
             state.currentRole = action.payload;
         },
         openEditRolesDialog(state) {
-            state.isEditRolesDialogOpen = true;
+            state.isSettingsDialogOpen = true;
         },
         closeEditRolesDialog(state) {
-            state.isEditRolesDialogOpen = false;
+            state.isSettingsDialogOpen = false;
         },
     },
     extraReducers: (builder) => {

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -47,7 +47,7 @@ const globalState: RootState = {
         currentRole: '',
         isLoading: false,
         hasRegistered: true,
-        isEditRolesDialogOpen: false,
+        isSettingsDialogOpen: false,
     },
     registerUser: {
         year: 0,


### PR DESCRIPTION
# Overview

* Allows users to properly switch between roles by toggling the role switches in the settings popup
* Disables some of the role switches if user does not have appropriate roles

# Changes

* Update dialog content
* Rename EditRolesDialog to SettingsDialog

# Questions & Notes

* Does not implement the user details form (year and specialty)

# Issue tracking

Closes #174 
Closes #173 

# Testing & Demo

Merge #202 locally and assign yourself `reviewer`, `interviewer` or `admin`, you should unlock the corresponding switches. As a volunteer, the `/resume-review` page should have an unstyled list of resumes available for review.