### PR TITLE
Implement ReviewResumeEditor component

### DIFF
--- a/www/src/components/pdf/PDFViewer.tsx
+++ b/www/src/components/pdf/PDFViewer.tsx
@@ -13,8 +13,9 @@ type ViewerConfig = {
 export type PDFViewerProps = {
     filePromise: () => Promise<ArrayBuffer>;
     fileName: string;
-    className: string;
+    className?: string;
     viewerConfig?: ViewerConfig;
+    onSave?: (arrayBuffer: ArrayBuffer) => void;
 };
 
 const PDFViewer: FC<PDFViewerProps> = (props: PDFViewerProps) => {
@@ -22,10 +23,13 @@ const PDFViewer: FC<PDFViewerProps> = (props: PDFViewerProps) => {
         const viewSDKClient = new ViewSDKClient();
         viewSDKClient.ready().then(() => {
             viewSDKClient.previewFileUsingFilePromise('adobe-dc-view', props.filePromise(), props.fileName, props.viewerConfig ?? {});
+            if (props.onSave !== undefined) {
+                viewSDKClient.onSave(props.onSave);
+            }
         });
     }, []);
 
-    return <Grid item id='adobe-dc-view' style={{ height: '100%' }} className={props.className} />;
+    return <Grid item id='adobe-dc-view' style={{ height: '100%', width: '100%' }} className={props.className} />;
 };
 
 export default PDFViewer;

--- a/www/src/components/pdf/ViewerSDKClient.ts
+++ b/www/src/components/pdf/ViewerSDKClient.ts
@@ -10,10 +10,9 @@ it. If you have received this file from a source other than Adobe,
 then your use, modification, or distribution of it requires the prior
 written permission of Adobe.
 */
-import axios from 'axios';
 
 import config from '../../util/config';
-import { arrayBufferToBase64 } from '../../util/helpers';
+
 declare global {
     interface Window {
         AdobeDC: any;
@@ -121,22 +120,15 @@ class ViewSDKClient {
         );
     }
 
-    registerSaveApiHandler() {
-        /* Define Save API Handler */
-        const saveApiHandler = (metaData: any, content: any) => {
-            return new Promise<saveAPIResponse | void>((resolve) => {
-                const formData = new FormData();
-                formData.append('file', arrayBufferToBase64(content));
-
-                // TODO: replace empty string with POST endpoint for updating pdf
-                axios
-                    .post('', formData, {
-                        headers: {
-                            'Content-Type': 'multipart/form-data',
-                        },
-                    })
-                    .then(() => resolve());
-            });
+    onSave(onSaveHandler: (newArrayBuffer: ArrayBuffer) => void) {
+        const saveApiHandler = async (metaData: any, content: ArrayBuffer): Promise<saveAPIResponse> => {
+            onSaveHandler(content);
+            return {
+                code: window.AdobeDC.View.Enum.ApiResponseCode.SUCCESS,
+                data: {
+                    metaData,
+                },
+            };
         };
 
         this.adobeDCView.registerCallback(window.AdobeDC.View.Enum.CallbackType.SAVE_API, saveApiHandler, {});

--- a/www/src/redux/substores/volunteer/slices/resumeReviewEditorSlice.ts
+++ b/www/src/redux/substores/volunteer/slices/resumeReviewEditorSlice.ts
@@ -1,0 +1,48 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import getMyDocuments from '../../../../routes/volunteer/thunks/getMyDocuments';
+import { Document } from '../../../../util/serverResponses';
+
+type ResumeReviewEditorState = {
+    documents: Document[] | null;
+    currentDocument: Document | null;
+    currentDocumentFromBackend: Document | null;
+    isLoading: boolean;
+};
+
+const initialState: ResumeReviewEditorState = {
+    documents: null,
+    currentDocument: null,
+    currentDocumentFromBackend: null,
+    isLoading: false,
+};
+
+export const resumeReviewEditorSlice = createSlice({
+    name: 'resumeReview/editor',
+    initialState,
+    reducers: {
+        updateCurrentDocumentContents: (state, action: PayloadAction<string>) => {
+            if (state.currentDocument === null) {
+                return;
+            }
+
+            state.currentDocument.base64Contents = action.payload;
+        },
+        cancelReviewResume: () => initialState,
+    },
+    extraReducers: (builder) => {
+        builder.addCase(getMyDocuments.pending, (state) => {
+            state.isLoading = true;
+        });
+        builder.addCase(getMyDocuments.fulfilled, (state, action) => {
+            state.isLoading = false;
+            state.documents = action.payload.documents;
+            state.currentDocumentFromBackend = action.payload.documents[0];
+            state.currentDocument = action.payload.documents[0];
+        });
+    },
+});
+
+export const { updateCurrentDocumentContents } = resumeReviewEditorSlice.actions;
+
+export default resumeReviewEditorSlice.reducer;

--- a/www/src/redux/substores/volunteer/volunteerStore.ts
+++ b/www/src/redux/substores/volunteer/volunteerStore.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import resumeReviewEditorReducer from './slices/resumeReviewEditorSlice';
 import resumeReviewReducer from './slices/resumeReviewSlice';
 
 const store = configureStore({
     reducer: {
         resumeReview: resumeReviewReducer,
+        resumeReviewEditor: resumeReviewEditorReducer,
     },
 });
 

--- a/www/src/routes/volunteer/ResumeReviewEditor.test.tsx
+++ b/www/src/routes/volunteer/ResumeReviewEditor.test.tsx
@@ -1,0 +1,77 @@
+import { Auth0ContextInterface, useAuth0, User } from '@auth0/auth0-react';
+import { AsyncThunkAction } from '@reduxjs/toolkit';
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+import { mocked } from 'ts-jest/utils';
+
+import PDFViewer from '../../components/pdf/PDFViewer';
+import { useVolunteerDispatch, useVolunteerSelector } from '../../redux/substores/volunteer/volunteerHooks';
+import { VolunteerState } from '../../redux/substores/volunteer/volunteerStore';
+import { WrappedDocuments } from '../../util/serverResponses';
+import mockConstants from '../../util/testConstants';
+import ResumeReviewEditor from './ResumeReviewEditor';
+import getMyDocuments, { AsyncThunkConfig, GetMyDocumentsParams } from './thunks/getMyDocuments';
+
+jest.mock('@auth0/auth0-react');
+const mockUseAuth0 = mocked(useAuth0, true);
+
+jest.mock('react-router-dom', () => {
+    return {
+        ...jest.requireActual('react-router-dom'),
+        useParams: () => ({
+            resumeReviewId: mockConstants.document1.resumeReviewId,
+        }),
+    };
+});
+
+jest.mock('../../redux/substores/volunteer/volunteerHooks');
+const mockUseVolunteerSelector = mocked(useVolunteerSelector, true);
+const mockUseVolunteerDispatch = mocked(useVolunteerDispatch, true);
+
+jest.mock('./thunks/getMyDocuments');
+const mockGetMyDocuments = mocked(getMyDocuments, true);
+
+describe('ReviewResume', () => {
+    let mockVolunteerState: VolunteerState;
+    const mockDispatch = jest.fn();
+    const mockGetAccessTokenSilently = jest.fn();
+    const mockAuth0State = {
+        getAccessTokenSilently: mockGetAccessTokenSilently,
+    } as unknown as Auth0ContextInterface<User>;
+
+    beforeEach(() => {
+        mockVolunteerState = mockConstants.volunteerState;
+
+        mockUseVolunteerSelector.mockImplementation((selector) => selector(mockVolunteerState));
+        mockUseVolunteerDispatch.mockReturnValue(mockDispatch);
+
+        mockUseAuth0.mockReturnValue(mockAuth0State);
+    });
+
+    it('fetches documents for currently reviewing', () => {
+        mockUseVolunteerSelector.mockImplementation((selector) => selector(mockVolunteerState));
+
+        const mockAction = {};
+        mockGetMyDocuments.mockReturnValueOnce(mockAction as AsyncThunkAction<WrappedDocuments, GetMyDocumentsParams, AsyncThunkConfig>);
+
+        mount(<ResumeReviewEditor />);
+
+        expect(mockDispatch).toBeCalledWith(mockAction);
+    });
+
+    it('Does not display PDFViewer while document is being loaded', () => {
+        const result = shallow(<ResumeReviewEditor />);
+
+        expect(result.find(PDFViewer)).toHaveLength(0);
+    });
+
+    it('displays PDFViewer when document has been loaded', () => {
+        mockVolunteerState.resumeReviewEditor.currentDocument = mockConstants.document1;
+
+        mockUseVolunteerSelector.mockImplementation((selector) => selector(mockVolunteerState));
+
+        const result = shallow(<ResumeReviewEditor />);
+
+        expect(result.find(PDFViewer)).toHaveLength(1);
+    });
+});

--- a/www/src/routes/volunteer/ResumeReviewEditor.tsx
+++ b/www/src/routes/volunteer/ResumeReviewEditor.tsx
@@ -1,14 +1,81 @@
-import React, { FC } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import { Button, Grid, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import DoneIcon from '@material-ui/icons/Done';
+import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
-interface ParamTypes {
-    resumeReviewId: string;
-}
+import LoadingOverlay from '../../components/LoadingOverlay';
+import PDFViewer from '../../components/pdf/PDFViewer';
+import { updateCurrentDocumentContents } from '../../redux/substores/volunteer/slices/resumeReviewEditorSlice';
+import { useVolunteerDispatch, useVolunteerSelector } from '../../redux/substores/volunteer/volunteerHooks';
+import { arrayBufferToBase64, base64ToArrayBuffer } from '../../util/helpers';
+import getMyDocuments from './thunks/getMyDocuments';
 
-const ResumeReviewEditor: FC = () => {
-    const { resumeReviewId } = useParams<ParamTypes>();
-    console.log(resumeReviewId);
-    return <p>🚧 Work in progress 🚧</p>;
+type ResumeReviewParams = {
+    resumeReviewId: string;
 };
+
+const ResumeReviewEditor: React.FC = () => {
+    const classes = useStyles();
+
+    const { resumeReviewId } = useParams<ResumeReviewParams>();
+
+    const { currentDocument, isLoading } = useVolunteerSelector((state) => state.resumeReviewEditor);
+    const { getAccessTokenSilently } = useAuth0();
+    const dispatch = useVolunteerDispatch();
+
+    useEffect(() => {
+        dispatch(getMyDocuments({ tokenAcquirer: getAccessTokenSilently, resumeReviewId: resumeReviewId }));
+    }, [resumeReviewId]);
+
+    const filePromise = async () => {
+        if (currentDocument === null) {
+            return new ArrayBuffer(0);
+        }
+        return base64ToArrayBuffer(currentDocument?.base64Contents);
+    };
+
+    return (
+        <Grid container>
+            <LoadingOverlay open={isLoading} />
+            <Grid item xs={8} className={classes.gridItem}>
+                <Typography>{resumeReviewId}</Typography>
+            </Grid>
+            <Grid container item xs={4} justify='flex-end' className={classes.gridItem}>
+                <Button variant='contained' color='primary' endIcon={<DoneIcon />}>
+                    Complete review
+                </Button>
+            </Grid>
+            <Grid container item xs={12}>
+                {currentDocument !== null && (
+                    <PDFViewer
+                        fileName={currentDocument.id}
+                        filePromise={filePromise}
+                        viewerConfig={{
+                            enableFormFilling: true,
+                            showAnnotationTools: true,
+                            showLeftHandPanel: true,
+                        }}
+                        onSave={(arrayBuffer) => {
+                            const base64Contents = arrayBufferToBase64(arrayBuffer);
+                            dispatch(updateCurrentDocumentContents(base64Contents));
+                        }}
+                        className={classes.pdfContainer}
+                    />
+                )}
+            </Grid>
+        </Grid>
+    );
+};
+
+const useStyles = makeStyles((theme) => ({
+    gridItem: {
+        padding: theme.spacing(1),
+    },
+    pdfContainer: {
+        minHeight: '60vh',
+    },
+}));
 
 export default ResumeReviewEditor;

--- a/www/src/routes/volunteer/thunks/getMyDocuments.test.ts
+++ b/www/src/routes/volunteer/thunks/getMyDocuments.test.ts
@@ -1,0 +1,34 @@
+import { AxiosResponse } from 'axios';
+import { mocked } from 'ts-jest/utils';
+
+import fetchWithToken from '../../../util/auth0/fetchWithToken';
+import { getMyDocuments as getMyDocumentsEndpoint } from '../../../util/endpoints';
+import Scope from '../../../util/scopes';
+import { WrappedDocuments } from '../../../util/serverResponses';
+import testConstants from '../../../util/testConstants';
+import { getMyDocuments } from './getMyDocuments';
+
+jest.mock('../../../util/auth0/fetchWithToken');
+const mockFetchWithToken = mocked(fetchWithToken, true);
+
+const mockGetTokenSilently = jest.fn();
+
+it('returns the documents on success', async () => {
+    const mockResponse = {
+        data: {
+            documents: [testConstants.document1],
+        },
+    };
+    mockFetchWithToken.mockResolvedValueOnce(mockResponse as AxiosResponse<WrappedDocuments>);
+
+    const result = await getMyDocuments({ resumeReviewId: testConstants.document1.resumeReviewId, tokenAcquirer: mockGetTokenSilently });
+
+    expect(mockFetchWithToken).toBeCalledWith(getMyDocumentsEndpoint(testConstants.document1.resumeReviewId), mockGetTokenSilently, [Scope.ReadMyDocuments]);
+    expect(result).toStrictEqual(mockResponse.data);
+});
+
+it('throws an error if fetch fails', async () => {
+    mockFetchWithToken.mockRejectedValueOnce({});
+
+    await expect(getMyDocuments({ resumeReviewId: testConstants.document1.resumeReviewId, tokenAcquirer: mockGetTokenSilently })).rejects.toThrow('Unable to fetch documents');
+});

--- a/www/src/routes/volunteer/thunks/getMyDocuments.ts
+++ b/www/src/routes/volunteer/thunks/getMyDocuments.ts
@@ -1,0 +1,34 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import { VolunteerDispatch, VolunteerState } from '../../../redux/substores/volunteer/volunteerStore';
+import fetchWithToken from '../../../util/auth0/fetchWithToken';
+import TokenAcquirer from '../../../util/auth0/TokenAcquirer';
+import { getMyDocuments as getMyDocumentsEndpoint } from '../../../util/endpoints';
+import Scope from '../../../util/scopes';
+import { WrappedDocuments } from '../../../util/serverResponses';
+
+export type GetMyDocumentsParams = {
+    tokenAcquirer: TokenAcquirer;
+    resumeReviewId: string;
+};
+
+export type AsyncThunkConfig = {
+    state: VolunteerState;
+    dispatch: VolunteerDispatch;
+    rejectValue: string;
+};
+
+export const getMyDocuments = async (params: GetMyDocumentsParams): Promise<WrappedDocuments> => {
+    const resumeReviewResult = await fetchWithToken<WrappedDocuments>(getMyDocumentsEndpoint(params.resumeReviewId), params.tokenAcquirer, [Scope.ReadMyDocuments]).catch(() => {
+        throw new Error('Unable to fetch documents');
+    });
+    return resumeReviewResult?.data ?? { documents: [] };
+};
+
+export default createAsyncThunk<WrappedDocuments, GetMyDocumentsParams, AsyncThunkConfig>('reviewResume/getMyDocuments', (params, thunkApi) => {
+    try {
+        return getMyDocuments(params);
+    } catch (e) {
+        return thunkApi.rejectWithValue(e);
+    }
+});

--- a/www/src/util/endpoints.ts
+++ b/www/src/util/endpoints.ts
@@ -5,7 +5,9 @@ export const getResumeReviews = `${config.server.endpoint}/api/v1/resume-reviews
 export const getUserRole = (userId: string): string => `${config.server.endpoint}/api/v1/users/${encodeURIComponent(userId)}/roles`;
 
 export const postUsers = `${config.server.endpoint}/api/v1/users`;
-export const postResumeReviews = `${config.server.endpoint}/api/v1/resume-reviews`;
-export const postDocuments = (resumeReviewId: string): string => `${config.server.endpoint}/api/v1/resume-reviews/${resumeReviewId}/documents`;
 
+export const postResumeReviews = `${config.server.endpoint}/api/v1/resume-reviews`;
 export const patchResumeReviews = (resumeReviewId: string): string => `${config.server.endpoint}/api/v1/resume-reviews/${resumeReviewId}`;
+
+export const postDocuments = (resumeReviewId: string): string => `${config.server.endpoint}/api/v1/resume-reviews/${resumeReviewId}/documents`;
+export const getMyDocuments = (resumeReviewId: string): string => `${config.server.endpoint}/api/v1/resume-reviews/${resumeReviewId}/documents`;

--- a/www/src/util/serverResponses.d.ts
+++ b/www/src/util/serverResponses.d.ts
@@ -55,6 +55,7 @@ export type Document = {
     resumeReviewId: string;
     createdAt: string;
     updatedAt: string;
+    base64Contents: string;
 };
 
 export type WrappedDocument = {
@@ -65,4 +66,8 @@ export type Role = {
     userId: string;
     role: string;
     createdAt: string;
+};
+
+export type WrappedDocuments = {
+    documents: Document[];
 };

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -1,5 +1,6 @@
 import { RootState } from '../redux/store';
 import { StudentState } from '../redux/substores/student/studentStore';
+import { VolunteerState } from '../redux/substores/volunteer/volunteerStore';
 import { Document, ResumeReview, Role, User } from './serverResponses';
 
 const user1: User = {
@@ -33,6 +34,7 @@ const document1: Document = {
     resumeReviewId: '123e4567-e89b-12d3-a456-426614174000',
     createdAt: '2021-06-14T06:09:19.373404+00:00',
     updatedAt: '2021-06-14T06:09:19.373404+00:00',
+    base64Contents: 'base64Contents',
 };
 
 const studentRole: Role = {
@@ -56,6 +58,7 @@ const globalState: RootState = {
         isLoading: false,
     },
 };
+
 const studentState: StudentState = {
     resumeReview: {
         resumeReviews: [],
@@ -69,4 +72,20 @@ const studentState: StudentState = {
     },
 };
 
-export default { user1, resumeReview1, document1, globalState, studentState, studentRole };
+const volunteerState: VolunteerState = {
+    resumeReview: {
+        availableResumes: [],
+        availableIsLoading: false,
+        reviewingIsLoading: false,
+        shouldReload: false,
+        reviewingResumes: [],
+    },
+    resumeReviewEditor: {
+        currentDocument: null,
+        currentDocumentFromBackend: null,
+        documents: null,
+        isLoading: false,
+    },
+};
+
+export default { user1, resumeReview1, document1, globalState, studentState, volunteerState, studentRole };


### PR DESCRIPTION
# Overview

* Allow volunteers to review resumes by opening `/resume-reviews/:resumeReviewId`

# Changes

* Add fetch documents thunk
* Display annotation tools in PDFViewer in resume review page for volunteers
* Add `onSave` prop to ViewerSDK to save edit file locally

# Questions & Notes

* The _Complete Button_ handler will be done in a separate PR
  * I need a refresher whether we should POST another document or PATCH the current one for this handler


# Issue tracking

Closes #200 

# Testing & Demo

https://user-images.githubusercontent.com/43416725/130524936-0ba17077-624e-43d8-baf7-476a5afe9920.mov

(sorry for low quality, there's a 10MB file cap :') )

Depends on #204 