### PR TITLE
GET All users and their roles

### DIFF
--- a/api/src/controllers/admin/getAllUsersInfo.test.ts
+++ b/api/src/controllers/admin/getAllUsersInfo.test.ts
@@ -1,0 +1,29 @@
+import { NextFunction, Request, Response } from 'express';
+import { mocked } from 'ts-jest/utils';
+
+import * as adminRepository from '../../repositories/adminRepository';
+import testConstants from '../../util/testConstants';
+import getAllUsersInfo from './getAllUsersInfo';
+
+jest.mock('../../repositories/adminRepository');
+const mockAdminRepository = mocked(adminRepository, true);
+
+let req: Partial<Request>;
+let res: Partial<Response>;
+let next: jest.MockedFunction<NextFunction>;
+
+beforeEach(() => {
+    req = {};
+    res = { status: jest.fn().mockReturnThis(), json: jest.fn().mockReturnThis() };
+    next = jest.fn();
+});
+
+it('gets all users', async () => {
+    const user1AndRole = { ...testConstants.user1, user_role: testConstants.userRole1.role };
+    mockAdminRepository.getUsersInfo.mockResolvedValueOnce([user1AndRole]);
+
+    await getAllUsersInfo(req as Request, res as Response, next);
+
+    expect(res.status).toBeCalledWith(200);
+    expect(res.json).toBeCalledWith(user1AndRole);
+});

--- a/api/src/controllers/admin/getAllUsersInfo.ts
+++ b/api/src/controllers/admin/getAllUsersInfo.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express';
+import { CamelCasedProperties } from 'type-fest';
+
+import * as adminRepository from '../../repositories/adminRepository';
+import { userRoleSelectable } from '../../repositories/adminRepository';
+import { toCamelCase } from '../../util/helper';
+import controller from '../controllerUtil';
+
+type ResBody = { users: CamelCasedProperties<userRoleSelectable>[] };
+
+/**
+ * Get all users and their roles.
+ * @param req HTTP request.
+ * @param res HTTP response.
+ * @returns List of all users and their roles.
+ */
+const getAllUsersInfo = controller(async (_req: Request, res: Response<ResBody>): Promise<void> => {
+    const users = await adminRepository.getUsersInfo();
+
+    res.status(200).json({ users: users.map((user) => toCamelCase(user)) });
+});
+
+export default getAllUsersInfo;

--- a/api/src/controllers/admin/index.ts
+++ b/api/src/controllers/admin/index.ts
@@ -1,0 +1,1 @@
+export { default as getAllUsersInfo } from './getAllUsersInfo';

--- a/api/src/repositories/adminRepository.ts
+++ b/api/src/repositories/adminRepository.ts
@@ -1,0 +1,24 @@
+import * as db from 'zapatos/db';
+import { conditions as dc } from 'zapatos/db';
+import type * as s from 'zapatos/schema';
+import { role_type } from 'zapatos/schema';
+
+import pool from '../util/pool';
+
+type userRoleSQL = s.users.SQL | s.user_roles.SQL;
+export type userRoleSelectable = s.users.JSONSelectable & { user_role: role_type };
+
+/**
+ * Gets all users and their roles.
+ * @returns List of all users and their assigned roles.
+ */
+const getUsersInfo = async (): Promise<userRoleSelectable[]> => {
+    return db.sql<userRoleSQL, userRoleSelectable[]>`
+    SELECT ${'users'}.*
+    FROM ${'users'}
+    JOIN ${'user_roles'}
+    ON ${'users'}.${'id'} = ${'user_roles'}.${'id'}
+    `.run(pool);
+};
+
+export { getUsersInfo };

--- a/api/src/routes/adminRoutes.ts
+++ b/api/src/routes/adminRoutes.ts
@@ -6,6 +6,6 @@ import Scope from '../types/scopes';
 
 export const router = express.Router();
 
-router.get('/admin/allUsers', middleware.authorize(Scope.ReadUsers), controller.getAllUsersInfo);
+router.get('/admin/allUsers', middleware.authorize(Scope.ReadAllUsersRoles), controller.getAllUsersInfo);
 
 export default router;

--- a/api/src/routes/adminRoutes.ts
+++ b/api/src/routes/adminRoutes.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+
+import * as controller from '../controllers/admin/index';
+import middleware from '../controllers/middleware';
+import Scope from '../types/scopes';
+
+export const router = express.Router();
+
+router.get('/admin/allUsers', middleware.authorize(Scope.ReadUsers), controller.getAllUsersInfo);
+
+export default router;

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import http from 'http';
 
 import middleware from './controllers/middleware';
+import adminRoutes from './routes/adminRoutes';
 import documentRoutes from './routes/documentRoutes';
 import resumeReviewRoutes from './routes/resumeReviewRoutes';
 import roleRoutes from './routes/roleRoutes';
@@ -28,6 +29,7 @@ router.use('/api/v1', userRoutes);
 router.use('/api/v1', resumeReviewRoutes);
 router.use('/api/v1', documentRoutes);
 router.use('/api/v1', roleRoutes);
+router.use('/api/v1', adminRoutes);
 
 /** Not found */
 router.use(middleware.notFound());

--- a/api/src/types/scopes.ts
+++ b/api/src/types/scopes.ts
@@ -23,6 +23,7 @@ enum Scope {
     ReadAllInterviews = 'read_all:interviews',
     CreateInterviews = 'create:interviews',
     DeleteInterviews = 'delete:interviews',
+    ReadAllUsersRoles = 'read:all_users_roles',
 }
 
 export default Scope;


### PR DESCRIPTION
# Overview

Implement endpoint to get a list of all users and their roles. This will be used in the Admin view to set the roles for users. 

# Changes

- Created admin related routes, repository, and controller 

# Questions & Notes

How do we ensure only an Admin user can access this endpoint? 
- I added a new scope in Auth0 →  `read:all_users_roles` (lemme know if I can rename it to something better) and I added this to the middleware for the route; is this all that's necessary? 

# Testing & Demo

See unit tests 
