### PR TITLE
Set default client to local.compe.plus

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -7,9 +7,9 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 1. Copy `www/.env.sample` to `www/.env`
 2. Using the `compe-plus-dev` tenant in [Auth0](https://manage.auth0.com/dashboard), expand _Applications_ on the left sidebar and click on _Compe+ Web Application_
 3. In the settings page, copy the domain and client ID to their respective fields in the `.env` file
-4. Copy the non-localhost _Allowed Callback URL_ to `/etc/hosts` as follows
+4. Add the following line in `/etc/hosts`
     ```
-    127.0.0.1     <NON_LOCALHOST_CALLBACK_URL_HERE>
+    127.0.0.1     local.compe.plus
     ```
 
 ## Available Scripts
@@ -19,7 +19,7 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.\
-Open [https://<NON_LOCALHOST_CALLBACK_URL_HERE>:3000](https://<NON_LOCALHOST_CALLBACK_URL_HERE>:3000) to view it in the browser.
+Open [https://local.compe.plus:3000](https://local.compe.plus:3000) to view it in the browser.
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.

--- a/www/package.json
+++ b/www/package.json
@@ -33,7 +33,7 @@
         "web-vitals": "^1.1.2"
     },
     "scripts": {
-        "start": "HTTPS=true react-scripts start",
+        "start": "HOST=local.compe.plus HTTPS=true react-scripts start",
         "build": "react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject",


### PR DESCRIPTION
# Overview

* Make `npm start` open `local.compe.plus` instead of `localhost` (which would fail auth)

# Changes

* Add `HOST` env variable to the `start` script

# Questions & Notes

* I thought exposing the local URL would pose to be a security risk but I just realized they also still a lot more things to actually start tampering our data

# Issue tracking


# Testing & Demo

Run `npm start`, https://local.compe.plus:3000 should open instead of http://localhost:3000