### PR TITLE
Implement ResumeList for students

### DIFF
--- a/www/src/components/TitledPage.tsx
+++ b/www/src/components/TitledPage.tsx
@@ -1,0 +1,33 @@
+import { Container, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import React, { ReactNode } from 'react';
+
+type TitledPageProps = {
+    title: string;
+    children: ReactNode;
+};
+
+const TitledPage: React.FC<TitledPageProps> = (props: TitledPageProps) => {
+    const classes = useStyles();
+
+    return (
+        <Container className={classes.page}>
+            <Typography variant='h1' className={classes.title} align='center'>
+                {props.title}
+            </Typography>
+            {props.children}
+        </Container>
+    );
+};
+
+const useStyles = makeStyles((theme) => ({
+    title: {
+        marginTop: theme.spacing(12),
+        marginBottom: theme.spacing(6),
+    },
+    page: {
+        height: '100%',
+    },
+}));
+
+export default TitledPage;

--- a/www/src/routes/student/ResumeReview.tsx
+++ b/www/src/routes/student/ResumeReview.tsx
@@ -1,7 +1,8 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { Grid, Typography } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 import React, { FC, useEffect } from 'react';
 
+import TitledPage from '../../components/TitledPage';
 import { useStudentDispatch, useStudentSelector } from '../../redux/substores/student/studentHooks';
 import getMyResumeReviews from '../../redux/substores/student/thunks/getMyResumeReviews';
 import ResumeList from './resumeReview/ResumeList';
@@ -17,14 +18,11 @@ const ResumeReview: FC = () => {
     }, []);
 
     return (
-        <div style={{ overflow: 'hidden' }}>
-            <Grid container justify='center' alignItems='center' spacing={8} style={{ marginTop: '10px', minHeight: '75vh' }}>
-                <Grid container item justify='center'>
-                    <Typography variant='h1'>Resume Review</Typography>
-                </Grid>
+        <TitledPage title='Resume Review'>
+            <Grid container item justify='center'>
                 {isUploading ? <UploadResume /> : <ResumeList />}
             </Grid>
-        </div>
+        </TitledPage>
     );
 };
 

--- a/www/src/routes/student/resumeReview/ResumeList.test.tsx
+++ b/www/src/routes/student/resumeReview/ResumeList.test.tsx
@@ -9,6 +9,7 @@ import getMyResumeReviews from '../../../redux/substores/student/thunks/getMyRes
 import testConstants from '../../../util/testConstants';
 import NoResumes from './NoResumes';
 import ResumeList from './ResumeList';
+import ResumeReviewCard from './ResumeReviewCard';
 
 jest.mock('../../../redux/substores/student/studentHooks');
 const mockUseStudentDispatch = mocked(useStudentDispatch, true);
@@ -37,5 +38,25 @@ describe('StudentResumeList', () => {
         render(<ResumeList />);
 
         expect(mockGetMyResumeReview).toBeCalled();
+    });
+
+    it.each(['seeking_reviewer', 'reviewing', 'finished', 'canceled'])('displays current and submitted resumes correctly', (state) => {
+        const mockCurrentResumeReview = testConstants.resumeReview1;
+        mockCurrentResumeReview.state = state as 'canceled' | 'finished' | 'reviewing' | 'seeking_reviewer';
+        studentStateMock.resumeReview.resumeReviews = [mockCurrentResumeReview];
+
+        mockUseStudentSelector.mockImplementation((selector) => selector(studentStateMock));
+
+        const result = shallow(<ResumeList />);
+
+        expect(result.find(ResumeReviewCard)).toHaveLength(1);
+
+        if (state === 'seeking_reviewer' || state === 'reviewing') {
+            // Current resumes
+            expect(result.text()).toContain('You have no submitted resumes');
+        } else {
+            // Submitted resumes
+            expect(result.text()).toContain('You have not submitted any resume for review');
+        }
     });
 });

--- a/www/src/routes/student/resumeReview/ResumeList.test.tsx
+++ b/www/src/routes/student/resumeReview/ResumeList.test.tsx
@@ -28,12 +28,6 @@ describe('StudentResumeList', () => {
         mockUseStudentSelector.mockImplementation((selector) => selector(studentStateMock));
     });
 
-    it('renders correctly for no resumes', () => {
-        const result = shallow(<ResumeList />);
-
-        expect(result.find(NoResumes)).toHaveLength(1);
-    });
-
     it('calls getMyResumeReviews', () => {
         render(<ResumeList />);
 
@@ -56,7 +50,7 @@ describe('StudentResumeList', () => {
             expect(result.text()).toContain('You have no submitted resumes');
         } else {
             // Submitted resumes
-            expect(result.text()).toContain('You have not submitted any resume for review');
+            expect(result.find(NoResumes)).toHaveLength(1);
         }
     });
 });

--- a/www/src/routes/student/resumeReview/ResumeList.tsx
+++ b/www/src/routes/student/resumeReview/ResumeList.tsx
@@ -23,8 +23,8 @@ const ResumeList: FC = () => {
         return <NoResumes />;
     }
 
-    const activeResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'seeking_reviewer' || resumeReview.state === 'reviewing');
-    const activeResume = activeResumes.length > 0 ? activeResumes[0] : null;
+    const currentResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'seeking_reviewer' || resumeReview.state === 'reviewing');
+    const currentResume = currentResumes.length > 0 ? currentResumes[0] : null;
     const submittedResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'finished' || resumeReview.state === 'canceled');
 
     return (
@@ -33,7 +33,7 @@ const ResumeList: FC = () => {
                 <Typography variant='h2' className={classes.sectionTitle}>
                     Current resume
                 </Typography>
-                {activeResume !== null ? <ResumeReviewCard resumeReview={activeResume} /> : <Typography>You have not submitted any resume for review</Typography>}
+                {currentResume !== null ? <ResumeReviewCard resumeReview={currentResume} /> : <Typography>You have not submitted any resume for review</Typography>}
             </section>
             <section className={classes.section}>
                 <Typography variant='h2' className={classes.sectionTitle}>

--- a/www/src/routes/student/resumeReview/ResumeList.tsx
+++ b/www/src/routes/student/resumeReview/ResumeList.tsx
@@ -1,5 +1,6 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { Button, Card, Collapse, Grid, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import dateFormat from 'dateformat';
 import React, { FC, useEffect } from 'react';
@@ -9,8 +10,9 @@ import getMyResumeReviews from '../../../redux/substores/student/thunks/getMyRes
 import NoResumes from './NoResumes';
 
 const ResumeList: FC = () => {
-    const { resumeReviews } = useStudentSelector((state) => state.resumeReview);
+    const classes = useStyles();
 
+    const { resumeReviews } = useStudentSelector((state) => state.resumeReview);
     const { getAccessTokenSilently } = useAuth0();
     const dispatch = useStudentDispatch();
 
@@ -22,16 +24,23 @@ const ResumeList: FC = () => {
         return <NoResumes />;
     }
 
+    const stateToDisplayNameMap = new Map([
+        ['canceled', 'Canceled'],
+        ['finished', 'Completed'],
+        ['reviewing', 'In review'],
+        ['seeking_reviewer', 'Pending'],
+    ]);
+
     const activeResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'seeking_reviewer' || resumeReview.state === 'reviewing');
     const activeResume = activeResumes.length > 0 ? activeResumes[0] : null;
     const submittedResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'finished' || resumeReview.state === 'canceled');
 
     return (
-        <>
-            <section>
-                <Typography>Current resume</Typography>
+        <Grid container item xs={12} justify='center'>
+            <Grid item xs={12}>
+                <Typography variant='h2'>Current resume</Typography>
                 {activeResume !== null ? (
-                    <Card>
+                    <Card className={classes.currentResumeCard}>
                         <Grid container>
                             <Grid item xs={3}>
                                 <Typography>Upload date</Typography>
@@ -40,37 +49,49 @@ const ResumeList: FC = () => {
                                 <Typography>{dateFormat(new Date(activeResume.createdAt), 'dddd, mmmm dS yyyy')}</Typography>
                             </Grid>
                             <Grid item xs={3}>
-                                <Typography>{activeResume.state}</Typography>
+                                <Typography align='right'>{stateToDisplayNameMap.get(activeResume.state)}</Typography>
                             </Grid>
 
-                            <Collapse in>
-                                <Grid item xs={3}>
-                                    <Typography>Last updated on</Typography>
-                                    <Typography>Reviewer ID</Typography>
-                                </Grid>
-                                <Grid item xs={6}>
-                                    <Typography>{activeResume.updatedAt}</Typography>
-                                    {/* TODO: get reviewer name */}
-                                    <Typography>{activeResume.reviewerId}</Typography>
-                                </Grid>
-                                <Grid item xs={3}>
-                                    <Button startIcon={<GetAppIcon />}>Download resume</Button>
-                                </Grid>
-                            </Collapse>
+                            <Grid item xs={12}>
+                                <Collapse in>
+                                    <Grid container>
+                                        <Grid item xs={3}>
+                                            <Typography>Last update on</Typography>
+                                            <Typography>Reviewer ID</Typography>
+                                        </Grid>
+                                        <Grid item xs={6}>
+                                            <Typography>{dateFormat(new Date(activeResume.updatedAt), 'dddd, mmmm dS yyyy')}</Typography>
+                                            {/* TODO: get reviewer name */}
+                                            <Typography>{activeResume.reviewerId}</Typography>
+                                        </Grid>
+                                        <Grid item xs={3}>
+                                            <Button startIcon={<GetAppIcon />} variant='contained' color='primary'>
+                                                Download resume
+                                            </Button>
+                                        </Grid>
+                                    </Grid>
+                                </Collapse>
+                            </Grid>
                         </Grid>
                     </Card>
                 ) : (
                     <Typography>You have not submitted any resume for review</Typography>
                 )}
-            </section>
-            <section>
-                <Typography>Submitted resumes</Typography>
+            </Grid>
+            <Grid item xs={12}>
+                <Typography variant='h2'>Submitted resumes</Typography>
                 {submittedResumes.map((submittedResume) => (
                     <Card key={submittedResume.id}>{submittedResume.id}</Card>
                 ))}
-            </section>
-        </>
+            </Grid>
+        </Grid>
     );
 };
+
+const useStyles = makeStyles((theme) => ({
+    currentResumeCard: {
+        padding: theme.spacing(2),
+    },
+}));
 
 export default ResumeList;

--- a/www/src/routes/student/resumeReview/ResumeList.tsx
+++ b/www/src/routes/student/resumeReview/ResumeList.tsx
@@ -19,10 +19,6 @@ const ResumeList: FC = () => {
         dispatch(getMyResumeReviews({ tokenAcquirer: getAccessTokenSilently }));
     }, []);
 
-    if (resumeReviews.length === 0) {
-        return <NoResumes />;
-    }
-
     const currentResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'seeking_reviewer' || resumeReview.state === 'reviewing');
     const currentResume = currentResumes.length > 0 ? currentResumes[0] : null;
     const submittedResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'finished' || resumeReview.state === 'canceled');
@@ -33,7 +29,7 @@ const ResumeList: FC = () => {
                 <Typography variant='h2' className={classes.sectionTitle}>
                     Current resume
                 </Typography>
-                {currentResume !== null ? <ResumeReviewCard resumeReview={currentResume} /> : <Typography>You have not submitted any resume for review</Typography>}
+                {currentResume !== null ? <ResumeReviewCard resumeReview={currentResume} /> : <NoResumes />}
             </section>
             <section className={classes.section}>
                 <Typography variant='h2' className={classes.sectionTitle}>

--- a/www/src/routes/student/resumeReview/ResumeList.tsx
+++ b/www/src/routes/student/resumeReview/ResumeList.tsx
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { Box, Card, Typography } from '@material-ui/core';
+import { Box, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import React, { FC, useEffect } from 'react';
 
@@ -28,7 +28,7 @@ const ResumeList: FC = () => {
     const submittedResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'finished' || resumeReview.state === 'canceled');
 
     return (
-        <Box display='flex' flexDirection='column'>
+        <Box display='flex' flexDirection='column' width='100'>
             <section className={classes.section}>
                 <Typography variant='h2' className={classes.sectionTitle}>
                     Current resume

--- a/www/src/routes/student/resumeReview/ResumeList.tsx
+++ b/www/src/routes/student/resumeReview/ResumeList.tsx
@@ -1,13 +1,12 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { Button, Card, Collapse, Grid, Typography } from '@material-ui/core';
+import { Box, Card, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import GetAppIcon from '@material-ui/icons/GetApp';
-import dateFormat from 'dateformat';
 import React, { FC, useEffect } from 'react';
 
 import { useStudentDispatch, useStudentSelector } from '../../../redux/substores/student/studentHooks';
 import getMyResumeReviews from '../../../redux/substores/student/thunks/getMyResumeReviews';
 import NoResumes from './NoResumes';
+import ResumeReviewCard from './ResumeReviewCard';
 
 const ResumeList: FC = () => {
     const classes = useStyles();
@@ -24,73 +23,38 @@ const ResumeList: FC = () => {
         return <NoResumes />;
     }
 
-    const stateToDisplayNameMap = new Map([
-        ['canceled', 'Canceled'],
-        ['finished', 'Completed'],
-        ['reviewing', 'In review'],
-        ['seeking_reviewer', 'Pending'],
-    ]);
-
     const activeResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'seeking_reviewer' || resumeReview.state === 'reviewing');
     const activeResume = activeResumes.length > 0 ? activeResumes[0] : null;
     const submittedResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'finished' || resumeReview.state === 'canceled');
 
     return (
-        <Grid container item xs={12} justify='center'>
-            <Grid item xs={12}>
-                <Typography variant='h2'>Current resume</Typography>
-                {activeResume !== null ? (
-                    <Card className={classes.currentResumeCard}>
-                        <Grid container>
-                            <Grid item xs={3}>
-                                <Typography>Upload date</Typography>
-                            </Grid>
-                            <Grid item xs={6}>
-                                <Typography>{dateFormat(new Date(activeResume.createdAt), 'dddd, mmmm dS yyyy')}</Typography>
-                            </Grid>
-                            <Grid item xs={3}>
-                                <Typography align='right'>{stateToDisplayNameMap.get(activeResume.state)}</Typography>
-                            </Grid>
-
-                            <Grid item xs={12}>
-                                <Collapse in>
-                                    <Grid container>
-                                        <Grid item xs={3}>
-                                            <Typography>Last update on</Typography>
-                                            <Typography>Reviewer ID</Typography>
-                                        </Grid>
-                                        <Grid item xs={6}>
-                                            <Typography>{dateFormat(new Date(activeResume.updatedAt), 'dddd, mmmm dS yyyy')}</Typography>
-                                            {/* TODO: get reviewer name */}
-                                            <Typography>{activeResume.reviewerId}</Typography>
-                                        </Grid>
-                                        <Grid item xs={3}>
-                                            <Button startIcon={<GetAppIcon />} variant='contained' color='primary'>
-                                                Download resume
-                                            </Button>
-                                        </Grid>
-                                    </Grid>
-                                </Collapse>
-                            </Grid>
-                        </Grid>
-                    </Card>
+        <Box display='flex' flexDirection='column'>
+            <section className={classes.section}>
+                <Typography variant='h2' className={classes.sectionTitle}>
+                    Current resume
+                </Typography>
+                {activeResume !== null ? <ResumeReviewCard resumeReview={activeResume} /> : <Typography>You have not submitted any resume for review</Typography>}
+            </section>
+            <section className={classes.section}>
+                <Typography variant='h2' className={classes.sectionTitle}>
+                    Submitted resumes
+                </Typography>
+                {submittedResumes.length > 0 ? (
+                    submittedResumes.map((submittedResume) => <ResumeReviewCard key={submittedResume.id} resumeReview={submittedResume} />)
                 ) : (
-                    <Typography>You have not submitted any resume for review</Typography>
+                    <Typography>You have no submitted resumes</Typography>
                 )}
-            </Grid>
-            <Grid item xs={12}>
-                <Typography variant='h2'>Submitted resumes</Typography>
-                {submittedResumes.map((submittedResume) => (
-                    <Card key={submittedResume.id}>{submittedResume.id}</Card>
-                ))}
-            </Grid>
-        </Grid>
+            </section>
+        </Box>
     );
 };
 
 const useStyles = makeStyles((theme) => ({
-    currentResumeCard: {
-        padding: theme.spacing(2),
+    section: {
+        marginBottom: theme.spacing(8),
+    },
+    sectionTitle: {
+        marginBottom: theme.spacing(2),
     },
 }));
 

--- a/www/src/routes/student/resumeReview/ResumeList.tsx
+++ b/www/src/routes/student/resumeReview/ResumeList.tsx
@@ -28,7 +28,7 @@ const ResumeList: FC = () => {
     const submittedResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'finished' || resumeReview.state === 'canceled');
 
     return (
-        <Box display='flex' flexDirection='column' width='100'>
+        <Box display='flex' flexDirection='column' width='100%'>
             <section className={classes.section}>
                 <Typography variant='h2' className={classes.sectionTitle}>
                     Current resume

--- a/www/src/routes/student/resumeReview/ResumeList.tsx
+++ b/www/src/routes/student/resumeReview/ResumeList.tsx
@@ -1,4 +1,7 @@
 import { useAuth0 } from '@auth0/auth0-react';
+import { Button, Card, Collapse, Grid, Typography } from '@material-ui/core';
+import GetAppIcon from '@material-ui/icons/GetApp';
+import dateFormat from 'dateformat';
 import React, { FC, useEffect } from 'react';
 
 import { useStudentDispatch, useStudentSelector } from '../../../redux/substores/student/studentHooks';
@@ -19,7 +22,55 @@ const ResumeList: FC = () => {
         return <NoResumes />;
     }
 
-    return <p>🚧 Work in progress 🚧</p>;
+    const activeResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'seeking_reviewer' || resumeReview.state === 'reviewing');
+    const activeResume = activeResumes.length > 0 ? activeResumes[0] : null;
+    const submittedResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'finished' || resumeReview.state === 'canceled');
+
+    return (
+        <>
+            <section>
+                <Typography>Current resume</Typography>
+                {activeResume !== null ? (
+                    <Card>
+                        <Grid container>
+                            <Grid item xs={3}>
+                                <Typography>Upload date</Typography>
+                            </Grid>
+                            <Grid item xs={6}>
+                                <Typography>{dateFormat(new Date(activeResume.createdAt), 'dddd, mmmm dS yyyy')}</Typography>
+                            </Grid>
+                            <Grid item xs={3}>
+                                <Typography>{activeResume.state}</Typography>
+                            </Grid>
+
+                            <Collapse in>
+                                <Grid item xs={3}>
+                                    <Typography>Last updated on</Typography>
+                                    <Typography>Reviewer ID</Typography>
+                                </Grid>
+                                <Grid item xs={6}>
+                                    <Typography>{activeResume.updatedAt}</Typography>
+                                    {/* TODO: get reviewer name */}
+                                    <Typography>{activeResume.reviewerId}</Typography>
+                                </Grid>
+                                <Grid item xs={3}>
+                                    <Button startIcon={<GetAppIcon />}>Download resume</Button>
+                                </Grid>
+                            </Collapse>
+                        </Grid>
+                    </Card>
+                ) : (
+                    <Typography>You have not submitted any resume for review</Typography>
+                )}
+            </section>
+            <section>
+                <Typography>Submitted resumes</Typography>
+                {submittedResumes.map((submittedResume) => (
+                    <Card key={submittedResume.id}>{submittedResume.id}</Card>
+                ))}
+            </section>
+        </>
+    );
 };
 
 export default ResumeList;

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.test.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.test.tsx
@@ -1,0 +1,48 @@
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import testConstants from '../../../util/testConstants';
+import ResumeReviewCard from './ResumeReviewCard';
+
+it.each(['cancelled', 'finished', 'reviewing', 'seeking_reviewer'])('displays the View button only when a review is not finished', (state) => {
+    const mockResumeReview = testConstants.resumeReview1;
+
+    mockResumeReview.state = state as 'canceled' | 'finished' | 'reviewing' | 'seeking_reviewer';
+
+    const result = shallow(<ResumeReviewCard resumeReview={mockResumeReview} />);
+
+    if (state === 'finished') {
+        expect(result.text()).not.toContain('View');
+    } else {
+        expect(result.text()).toContain('View');
+    }
+});
+
+it.each(['cancelled', 'finished', 'reviewing', 'seeking_reviewer'])('displays the Cancel button only when a review is still seeking a reviewer', (state) => {
+    const mockResumeReview = testConstants.resumeReview1;
+
+    mockResumeReview.state = state as 'canceled' | 'finished' | 'reviewing' | 'seeking_reviewer';
+
+    const result = shallow(<ResumeReviewCard resumeReview={mockResumeReview} />);
+
+    if (state === 'seeking_reviewer') {
+        expect(result.text()).toContain('Cancel review');
+    } else {
+        expect(result.text()).not.toContain('Cancel review');
+    }
+});
+
+it.each(['cancelled', 'finished', 'reviewing', 'seeking_reviewer'])('displays the expand icon only when a review is finished', (state) => {
+    const mockResumeReview = testConstants.resumeReview1;
+
+    mockResumeReview.state = state as 'canceled' | 'finished' | 'reviewing' | 'seeking_reviewer';
+
+    const result = shallow(<ResumeReviewCard resumeReview={mockResumeReview} />);
+
+    if (state === 'finished') {
+        expect(result.find(ExpandMoreIcon)).toHaveLength(1);
+    } else {
+        expect(result.find(ExpandMoreIcon)).toHaveLength(0);
+    }
+});

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -28,7 +28,7 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
             <Grid container>
                 <Grid container alignItems='center' item xs={6}>
                     <Typography>
-                        <b>{dateFormat(new Date(resumeReview.createdAt), 'dddd, mmmm dS yyyy')}</b>
+                        <b>Uploaded on:</b> {dateFormat(new Date(resumeReview.createdAt), 'dddd, mmmm dS yyyy')}
                     </Typography>
                 </Grid>
                 <Grid container justify='space-around' item xs={3}>

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -27,51 +27,55 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
         <Card className={classes.currentResumeCard}>
             <CardContent>
                 <Grid container>
-                    <Grid item xs={3}>
-                        <Typography>Upload date</Typography>
-                    </Grid>
                     <Grid item xs={6}>
                         <Typography>{dateFormat(new Date(resumeReview.createdAt), 'dddd, mmmm dS yyyy')}</Typography>
+                    </Grid>
+                    <Grid container justify='space-around' item xs={3}>
+                        <Button>View</Button>
+                        {resumeReview.state === 'seeking_reviewer' && <Button>Cancel review</Button>}
                     </Grid>
                     <Grid item xs={3}>
                         <Typography align='right'>{stateToDisplayNameMap.get(resumeReview.state)}</Typography>
                     </Grid>
 
-                    <Grid item xs={12}>
-                        <Collapse in={isExpanded}>
-                            <Grid container>
-                                <Grid item xs={3}>
-                                    <Typography>Last update on</Typography>
-                                    <Typography>Reviewer ID</Typography>
+                    {resumeReview.state === 'finished' && (
+                        <Grid item xs={12}>
+                            <Collapse in={isExpanded}>
+                                <Grid container>
+                                    <Grid item xs={6}>
+                                        <Typography>Review completed on {dateFormat(new Date(resumeReview.updatedAt), 'dddd, mmmm dS yyyy')}</Typography>
+                                    </Grid>
+                                    <Grid item xs={3}>
+                                        <Typography>{dateFormat(new Date(resumeReview.updatedAt), 'dddd, mmmm dS yyyy')}</Typography>
+                                        {/* TODO: get reviewer name */}
+                                        <Typography>{resumeReview.reviewerId ?? '-'}</Typography>
+                                    </Grid>
+                                    <Grid container justify='flex-end' item xs={3}>
+                                        <Button startIcon={<GetAppIcon />} variant='contained' color='primary'>
+                                            Download resume
+                                        </Button>
+                                    </Grid>
                                 </Grid>
-                                <Grid item xs={6}>
-                                    <Typography>{dateFormat(new Date(resumeReview.updatedAt), 'dddd, mmmm dS yyyy')}</Typography>
-                                    {/* TODO: get reviewer name */}
-                                    <Typography>{resumeReview.reviewerId ?? '-'}</Typography>
-                                </Grid>
-                                <Grid container justify='flex-end' item xs={3}>
-                                    <Button startIcon={<GetAppIcon />} variant='contained' color='primary'>
-                                        Download resume
-                                    </Button>
-                                </Grid>
-                            </Grid>
-                        </Collapse>
-                    </Grid>
+                            </Collapse>
+                        </Grid>
+                    )}
                 </Grid>
             </CardContent>
-            <CardActions>
-                <IconButton
-                    className={clsx(classes.expand, {
-                        [classes.expandOpen]: isExpanded,
-                    })}
-                    onClick={() => setIsExpanded(!isExpanded)}
-                    aria-expanded={isExpanded}
-                    aria-label='show more'
-                    size='small'
-                >
-                    <ExpandMoreIcon />
-                </IconButton>
-            </CardActions>
+            {resumeReview.state === 'finished' && (
+                <CardActions>
+                    <IconButton
+                        className={clsx(classes.expand, {
+                            [classes.expandOpen]: isExpanded,
+                        })}
+                        onClick={() => setIsExpanded(!isExpanded)}
+                        aria-expanded={isExpanded}
+                        aria-label='show more'
+                        size='small'
+                    >
+                        <ExpandMoreIcon />
+                    </IconButton>
+                </CardActions>
+            )}
         </Card>
     );
 };

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -1,0 +1,95 @@
+import { Button, Card, CardActions, CardContent, Collapse, Grid, IconButton, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import GetAppIcon from '@material-ui/icons/GetApp';
+import clsx from 'clsx';
+import dateFormat from 'dateformat';
+import React, { FC, useState } from 'react';
+
+import { ResumeReview } from '../../../util/serverResponses';
+
+type ResumeReviewCardProps = {
+    resumeReview: ResumeReview;
+};
+
+const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeReviewCardProps) => {
+    const classes = useStyles();
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const stateToDisplayNameMap = new Map([
+        ['canceled', 'Canceled'],
+        ['finished', 'Completed'],
+        ['reviewing', 'In review'],
+        ['seeking_reviewer', 'Pending'],
+    ]);
+
+    return (
+        <Card className={classes.currentResumeCard}>
+            <CardContent>
+                <Grid container>
+                    <Grid item xs={3}>
+                        <Typography>Upload date</Typography>
+                    </Grid>
+                    <Grid item xs={6}>
+                        <Typography>{dateFormat(new Date(resumeReview.createdAt), 'dddd, mmmm dS yyyy')}</Typography>
+                    </Grid>
+                    <Grid item xs={3}>
+                        <Typography align='right'>{stateToDisplayNameMap.get(resumeReview.state)}</Typography>
+                    </Grid>
+
+                    <Grid item xs={12}>
+                        <Collapse in={isExpanded}>
+                            <Grid container>
+                                <Grid item xs={3}>
+                                    <Typography>Last update on</Typography>
+                                    <Typography>Reviewer ID</Typography>
+                                </Grid>
+                                <Grid item xs={6}>
+                                    <Typography>{dateFormat(new Date(resumeReview.updatedAt), 'dddd, mmmm dS yyyy')}</Typography>
+                                    {/* TODO: get reviewer name */}
+                                    <Typography>{resumeReview.reviewerId ?? '-'}</Typography>
+                                </Grid>
+                                <Grid container justify='flex-end' item xs={3}>
+                                    <Button startIcon={<GetAppIcon />} variant='contained' color='primary'>
+                                        Download resume
+                                    </Button>
+                                </Grid>
+                            </Grid>
+                        </Collapse>
+                    </Grid>
+                </Grid>
+            </CardContent>
+            <CardActions>
+                <IconButton
+                    className={clsx(classes.expand, {
+                        [classes.expandOpen]: isExpanded,
+                    })}
+                    onClick={() => setIsExpanded(!isExpanded)}
+                    aria-expanded={isExpanded}
+                    aria-label='show more'
+                    size='small'
+                >
+                    <ExpandMoreIcon />
+                </IconButton>
+            </CardActions>
+        </Card>
+    );
+};
+
+const useStyles = makeStyles((theme) => ({
+    currentResumeCard: {
+        padding: theme.spacing(1),
+    },
+    expand: {
+        transform: 'rotate(0deg)',
+        marginLeft: 'auto',
+        transition: theme.transitions.create('transform', {
+            duration: theme.transitions.duration.shortest,
+        }),
+    },
+    expandOpen: {
+        transform: 'rotate(180deg)',
+    },
+}));
+
+export default ResumeReviewCard;

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -86,7 +86,7 @@ const useStyles = makeStyles((theme) => ({
     },
     expand: {
         transform: 'rotate(0deg)',
-        margin: theme.spacing(2),
+        marginLeft: theme.spacing(1),
         transition: theme.transitions.create('transform', {
             duration: theme.transitions.duration.shortest,
         }),

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, CardActions, CardContent, Collapse, Grid, IconButton, Typography } from '@material-ui/core';
+import { Button, Card, Collapse, Grid, IconButton, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import GetAppIcon from '@material-ui/icons/GetApp';
@@ -25,56 +25,52 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
 
     return (
         <Card className={classes.currentResumeCard}>
-            <CardContent>
-                <Grid container>
-                    <Grid item xs={6}>
-                        <Typography>{dateFormat(new Date(resumeReview.createdAt), 'dddd, mmmm dS yyyy')}</Typography>
-                    </Grid>
-                    <Grid container justify='space-around' item xs={3}>
-                        <Button>View</Button>
-                        {resumeReview.state === 'seeking_reviewer' && <Button>Cancel review</Button>}
-                    </Grid>
-                    <Grid item xs={3}>
-                        <Typography align='right'>{stateToDisplayNameMap.get(resumeReview.state)}</Typography>
-                    </Grid>
-
-                    {resumeReview.state === 'finished' && (
-                        <Grid item xs={12}>
-                            <Collapse in={isExpanded}>
-                                <Grid container>
-                                    <Grid item xs={6}>
-                                        <Typography>Review completed on {dateFormat(new Date(resumeReview.updatedAt), 'dddd, mmmm dS yyyy')}</Typography>
-                                    </Grid>
-                                    <Grid item xs={3}>
-                                        <Typography>{dateFormat(new Date(resumeReview.updatedAt), 'dddd, mmmm dS yyyy')}</Typography>
-                                        {/* TODO: get reviewer name */}
-                                        <Typography>{resumeReview.reviewerId ?? '-'}</Typography>
-                                    </Grid>
-                                    <Grid container justify='flex-end' item xs={3}>
-                                        <Button startIcon={<GetAppIcon />} variant='contained' color='primary'>
-                                            Download resume
-                                        </Button>
-                                    </Grid>
-                                </Grid>
-                            </Collapse>
-                        </Grid>
-                    )}
+            <Grid container>
+                <Grid container alignItems='center' item xs={6}>
+                    <Typography>{dateFormat(new Date(resumeReview.createdAt), 'dddd, mmmm dS yyyy')}</Typography>
                 </Grid>
-            </CardContent>
+                <Grid container justify='space-around' item xs={3}>
+                    {resumeReview.state !== 'finished' && <Button>View</Button>}
+                    {resumeReview.state === 'seeking_reviewer' && <Button>Cancel review</Button>}
+                </Grid>
+                <Grid container alignItems='center' justify='flex-end' item xs={3}>
+                    <Typography align='right'>{stateToDisplayNameMap.get(resumeReview.state)}</Typography>
+                </Grid>
+
+                {resumeReview.state === 'finished' && (
+                    <Grid item xs={12}>
+                        <Collapse in={isExpanded}>
+                            <Grid container>
+                                <Grid item xs={6}>
+                                    <Typography>Review completed on {dateFormat(new Date(resumeReview.updatedAt), 'dddd, mmmm dS yyyy')}</Typography>
+                                </Grid>
+                                <Grid item xs={3}>
+                                    <Typography>{dateFormat(new Date(resumeReview.updatedAt), 'dddd, mmmm dS yyyy')}</Typography>
+                                    {/* TODO: get reviewer name */}
+                                    <Typography>{resumeReview.reviewerId ?? '-'}</Typography>
+                                </Grid>
+                                <Grid container justify='flex-end' item xs={3}>
+                                    <Button startIcon={<GetAppIcon />} variant='contained' color='primary'>
+                                        Download resume
+                                    </Button>
+                                </Grid>
+                            </Grid>
+                        </Collapse>
+                    </Grid>
+                )}
+            </Grid>
             {resumeReview.state === 'finished' && (
-                <CardActions>
-                    <IconButton
-                        className={clsx(classes.expand, {
-                            [classes.expandOpen]: isExpanded,
-                        })}
-                        onClick={() => setIsExpanded(!isExpanded)}
-                        aria-expanded={isExpanded}
-                        aria-label='show more'
-                        size='small'
-                    >
-                        <ExpandMoreIcon />
-                    </IconButton>
-                </CardActions>
+                <IconButton
+                    className={clsx(classes.expand, {
+                        [classes.expandOpen]: isExpanded,
+                    })}
+                    onClick={() => setIsExpanded(!isExpanded)}
+                    aria-expanded={isExpanded}
+                    aria-label='show more'
+                    size='small'
+                >
+                    <ExpandMoreIcon />
+                </IconButton>
             )}
         </Card>
     );
@@ -82,7 +78,7 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
 
 const useStyles = makeStyles((theme) => ({
     currentResumeCard: {
-        padding: theme.spacing(1),
+        padding: theme.spacing(2),
     },
     expand: {
         transform: 'rotate(0deg)',

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -24,7 +24,7 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
     ]);
 
     return (
-        <Card className={classes.currentResumeCard}>
+        <Card className={classes.currentResumeCard} elevation={0}>
             <Grid container>
                 <Grid container alignItems='center' item xs={6}>
                     <Typography>{dateFormat(new Date(resumeReview.createdAt), 'dddd, mmmm dS yyyy')}</Typography>

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -82,6 +82,7 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
 const useStyles = makeStyles((theme) => ({
     currentResumeCard: {
         padding: theme.spacing(2),
+        marginBottom: theme.spacing(2),
     },
     expand: {
         transform: 'rotate(0deg)',

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -27,7 +27,9 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
         <Card className={classes.currentResumeCard} elevation={0}>
             <Grid container>
                 <Grid container alignItems='center' item xs={6}>
-                    <Typography>{dateFormat(new Date(resumeReview.createdAt), 'dddd, mmmm dS yyyy')}</Typography>
+                    <Typography>
+                        <b>{dateFormat(new Date(resumeReview.createdAt), 'dddd, mmmm dS yyyy')}</b>
+                    </Typography>
                 </Grid>
                 <Grid container justify='space-around' item xs={3}>
                     {resumeReview.state !== 'finished' && <Button>View</Button>}
@@ -35,21 +37,35 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
                 </Grid>
                 <Grid container alignItems='center' justify='flex-end' item xs={3}>
                     <Typography align='right'>{stateToDisplayNameMap.get(resumeReview.state)}</Typography>
+                    {resumeReview.state === 'finished' && (
+                        <IconButton
+                            className={clsx(classes.expand, {
+                                [classes.expandOpen]: isExpanded,
+                            })}
+                            onClick={() => setIsExpanded(!isExpanded)}
+                            aria-expanded={isExpanded}
+                            aria-label='show more'
+                            size='small'
+                        >
+                            <ExpandMoreIcon />
+                        </IconButton>
+                    )}
                 </Grid>
 
                 {resumeReview.state === 'finished' && (
                     <Grid item xs={12}>
                         <Collapse in={isExpanded}>
                             <Grid container>
-                                <Grid item xs={6}>
-                                    <Typography>Review completed on {dateFormat(new Date(resumeReview.updatedAt), 'dddd, mmmm dS yyyy')}</Typography>
+                                <Grid item xs={9}>
+                                    <Typography>
+                                        <b>Review completed on:</b> {dateFormat(new Date(resumeReview.updatedAt), 'dddd, mmmm dS yyyy')}
+                                    </Typography>
+                                    <Typography>
+                                        {/* // TODO: Update to reviewer name */}
+                                        <b>Reviewer ID:</b> {resumeReview.reviewerId}
+                                    </Typography>
                                 </Grid>
-                                <Grid item xs={3}>
-                                    <Typography>{dateFormat(new Date(resumeReview.updatedAt), 'dddd, mmmm dS yyyy')}</Typography>
-                                    {/* TODO: get reviewer name */}
-                                    <Typography>{resumeReview.reviewerId ?? '-'}</Typography>
-                                </Grid>
-                                <Grid container justify='flex-end' item xs={3}>
+                                <Grid container justify='flex-end' alignItems='center' item xs={3}>
                                     <Button startIcon={<GetAppIcon />} variant='contained' color='primary'>
                                         Download resume
                                     </Button>
@@ -59,19 +75,6 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
                     </Grid>
                 )}
             </Grid>
-            {resumeReview.state === 'finished' && (
-                <IconButton
-                    className={clsx(classes.expand, {
-                        [classes.expandOpen]: isExpanded,
-                    })}
-                    onClick={() => setIsExpanded(!isExpanded)}
-                    aria-expanded={isExpanded}
-                    aria-label='show more'
-                    size='small'
-                >
-                    <ExpandMoreIcon />
-                </IconButton>
-            )}
         </Card>
     );
 };
@@ -82,7 +85,7 @@ const useStyles = makeStyles((theme) => ({
     },
     expand: {
         transform: 'rotate(0deg)',
-        marginLeft: 'auto',
+        margin: theme.spacing(2),
         transition: theme.transitions.create('transform', {
             duration: theme.transitions.duration.shortest,
         }),

--- a/www/src/styles/theme.ts
+++ b/www/src/styles/theme.ts
@@ -1,6 +1,7 @@
 import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
 import { PaletteOptions } from '@material-ui/core/styles/createPalette';
 import { TypographyOptions } from '@material-ui/core/styles/createTypography';
+import { Overrides } from '@material-ui/core/styles/overrides';
 
 declare module '@material-ui/core/styles/createMuiTheme' {
     interface ThemeOptions {
@@ -11,7 +12,7 @@ declare module '@material-ui/core/styles/createMuiTheme' {
 const palette: PaletteOptions = {
     primary: {
         main: '#79B178',
-        light: '#E2F8E2',
+        light: '#ABD3AB',
         dark: '#124612',
         contrastText: '#fff',
     },
@@ -62,4 +63,22 @@ const typography: TypographyOptions = {
 
 const themeName = 'CompE+ Theme';
 
-export default responsiveFontSizes(createMuiTheme({ palette, typography, themeName }));
+const overrides: Overrides = {
+    MuiPaper: {
+        rounded: {
+            borderRadius: 0,
+        },
+        root: {
+            backgroundColor: '#ABD3AB',
+        },
+    },
+};
+
+export default responsiveFontSizes(
+    createMuiTheme({
+        palette,
+        typography,
+        themeName,
+        overrides,
+    }),
+);


### PR DESCRIPTION
# Overview

Display list of resume reviews that a student has and fix variable top margin on titled pages using `TitledPage` component

# Changes

* Created ResumeReviewCard to display resume review objects
* Customized material UI to not use rounded corners by default

# Questions & Notes

* Current resume is for resumes just submitted or still under review
* Submitted resumes is for completed/cancelled reviews
* Buttons like _View_ and _Download Resume_ aren't functional yet, they'll be followed up after I work on the POST document for a reviewer
* `cancelled` should display `<NoResumes />` (like `finished`) instead of the simple text portrayed in the screenshot below

# Issue tracking

Closes #125 

# Testing & Demo

Refer to unit tests and see screenshots below

| State | Result |
| --- | --- |
| seeking_reviewer | <img width="1796" alt="seeking_reviewer" src="https://user-images.githubusercontent.com/43416725/131916594-45f13022-dfa5-474e-81af-3415fa1871e1.png"> |
| reviewing | <img width="1800" alt="in_review" src="https://user-images.githubusercontent.com/43416725/131916592-7aab5829-4858-49d8-b240-8e1eec76df89.png"> |
| finished | ![image](https://user-images.githubusercontent.com/43416725/131938665-a486448e-54f1-46a3-af8e-344bd940e225.png) |
| cancelled | <img width="1799" alt="canceled" src="https://user-images.githubusercontent.com/43416725/131916588-e4af6785-d080-4e15-b299-35bfdbfe4ca1.png"> |
