### PR TITLE
Only allow ualberta.ca emails to login to our app

### DIFF
--- a/auth0/rules/Email domain whitelist.js
+++ b/auth0/rules/Email domain whitelist.js
@@ -1,0 +1,18 @@
+function emailDomainWhitelist(user, context, callback) {
+    // Access should only be granted to verified users.
+    if (!user.email || !user.email_verified) {
+        return callback(new UnauthorizedError('Access denied.'));
+    }
+
+    const whitelist = ['ualberta.ca']; //authorized domains
+    const userHasAccess = whitelist.some(function (domain) {
+        const emailSplit = user.email.split('@');
+        return emailSplit[emailSplit.length - 1].toLowerCase() === domain;
+    });
+
+    if (!userHasAccess) {
+        return callback(new UnauthorizedError('You can only use CompE+ with your ualberta.ca account'));
+    }
+
+    return callback(null, user, context);
+}

--- a/auth0/rules/domainWhitelist.js
+++ b/auth0/rules/domainWhitelist.js
@@ -11,7 +11,7 @@ function emailDomainWhitelist(user, context, callback) {
     });
 
     if (!userHasAccess) {
-        return callback(new UnauthorizedError('You can only use CompE+ with your ualberta.ca account'));
+        return callback(new UnauthorizedError('You can only use CompE+ with your ualberta.ca account. You might need to clear your cookies to choose another account.'));
     }
 
     return callback(null, user, context);

--- a/auth0/rules/domainWhitelist.js
+++ b/auth0/rules/domainWhitelist.js
@@ -11,7 +11,7 @@ function emailDomainWhitelist(user, context, callback) {
     });
 
     if (!userHasAccess) {
-        return callback(new UnauthorizedError('You can only use CompE+ with your ualberta.ca account. You might need to clear your cookies to choose another account.'));
+        return callback(new UnauthorizedError('You can only use CompE+ with your ualberta.ca account.\nYou might need to clear your cookies to choose another account.'));
     }
 
     return callback(null, user, context);

--- a/auth0/tenant.yaml
+++ b/auth0/tenant.yaml
@@ -1,6 +1,6 @@
 rules:
     - name: Email domain whitelist
-      script: ./rules/Email domain whitelist.js
+      script: ./rules/domainWhitelist.js
       stage: login_success
       enabled: true
       order: 1

--- a/auth0/tenant.yaml
+++ b/auth0/tenant.yaml
@@ -1,4 +1,9 @@
-rules: []
+rules:
+    - name: Email domain whitelist
+      script: ./rules/Email domain whitelist.js
+      stage: login_success
+      enabled: true
+      order: 1
 rulesConfigs: []
 hooks: []
 pages: []

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -39,7 +39,7 @@ const getContentByRole = (role: string) => {
 };
 
 const App: FC = () => {
-    const { isAuthenticated, getAccessTokenSilently, isLoading: isAuth0Loading, user } = useAuth0();
+    const { isAuthenticated, getAccessTokenSilently, isLoading: isAuth0Loading, user, error } = useAuth0();
 
     const { currentRole, isLoading, hasRegistered } = useAppSelector((state) => state.user);
     const dispatch = useAppDispatch();
@@ -57,6 +57,12 @@ const App: FC = () => {
             dispatch(getUserRole({ userId: user.sub, tokenAcquirer: getAccessTokenSilently }));
         }
     }, [hasRegistered]);
+
+    useEffect(() => {
+        if (error !== undefined) {
+            alert(error.message);
+        }
+    }, [error]);
 
     return (
         <ThemeProvider theme={theme}>

--- a/www/src/providers/Auth0ProviderWithHistory.tsx
+++ b/www/src/providers/Auth0ProviderWithHistory.tsx
@@ -17,7 +17,7 @@ const Auth0ProviderWithHistory: FC<Auth0ProviderWithHistoryProps> = ({ children 
     };
 
     return (
-        <Auth0Provider domain={domain} clientId={clientId} redirectUri={window.location.origin} onRedirectCallback={onRedirectCallback} audience={config.server.audience} scope={'call:ping'}>
+        <Auth0Provider domain={domain} clientId={clientId} redirectUri={window.location.origin} onRedirectCallback={onRedirectCallback} audience={config.server.audience}>
             {children}
         </Auth0Provider>
     );


### PR DESCRIPTION
# Overview

* Display error and do not proceed with log-in when user logs in using their personal (non-ualberta.ca) email

# Changes

* Added rule in Auth0 that validates the email domain
* Remove unused scope field in `Auth0Provider`

# Questions & Notes

* When Auth0 triggers the _UnauthorizedError_, the `isAuthenticated` flag won't be turned on so everything should stay as is (user isn't logged in even if they chose their personal email in the selection page)
* User has to clear their cookies to be able to choose a second account. We could maybe simplify this by auto clearing their cookies(?)
* TODO: Replicate auth0 changes in prod

# Issue tracking

Closes #218 

# Testing & Demo

Try log-in to staging with your personal email