### PR TITLE
Implement cancel review

### DIFF
--- a/www/src/redux/substores/student/slices/resumeReviewSlice.ts
+++ b/www/src/redux/substores/student/slices/resumeReviewSlice.ts
@@ -1,18 +1,21 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { ResumeReview } from '../../../../util/serverResponses';
+import cancelMyResumeReview from '../thunks/cancelResumeReview';
 import getMyResumeReviews from '../thunks/getMyResumeReviews';
 
 type ResumeReviewState = {
     resumeReviews: ResumeReview[];
     isLoading: boolean;
     isUploading: boolean;
+    shouldReload: boolean;
 };
 
 const initialState: ResumeReviewState = {
     resumeReviews: [],
     isUploading: false,
     isLoading: false,
+    shouldReload: true,
 };
 
 export const resumeReviewSlice = createSlice({
@@ -30,6 +33,14 @@ export const resumeReviewSlice = createSlice({
         builder.addCase(getMyResumeReviews.fulfilled, (state, action) => {
             state.isLoading = false;
             state.resumeReviews = action.payload.resumeReviews;
+            state.shouldReload = false;
+        });
+        builder.addCase(cancelMyResumeReview.pending, (state) => {
+            state.isLoading = true;
+        });
+        builder.addCase(cancelMyResumeReview.fulfilled, (state) => {
+            state.isLoading = false;
+            state.shouldReload = true;
         });
     },
 });

--- a/www/src/redux/substores/student/thunks/cancelResumeReview.ts
+++ b/www/src/redux/substores/student/thunks/cancelResumeReview.ts
@@ -27,7 +27,7 @@ export const cancelMyResumeReview = async (params: CancelResumeReviewParams): Pr
         },
         [Scope.UpdateMyResumeReviews],
     ).catch(() => {
-        alert('Unable to download resume');
+        alert('Unable to cancel resume review');
     });
 };
 

--- a/www/src/redux/substores/student/thunks/cancelResumeReview.ts
+++ b/www/src/redux/substores/student/thunks/cancelResumeReview.ts
@@ -1,0 +1,40 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import patchWithToken from '../../../../util/auth0/patchWithToken';
+import TokenAcquirer from '../../../../util/auth0/TokenAcquirer';
+import { patchMyResumeReview } from '../../../../util/endpoints';
+import Scope from '../../../../util/scopes';
+import { WrappedDocuments } from '../../../../util/serverResponses';
+import { StudentDispatch, StudentState } from '../studentStore';
+
+export type CancelResumeReviewParams = {
+    tokenAcquirer: TokenAcquirer;
+    resumeReviewId: string;
+};
+
+export type AsyncThunkConfig = {
+    state: StudentState;
+    dispatch: StudentDispatch;
+    rejectValue: string;
+};
+
+export const cancelMyResumeReview = async (params: CancelResumeReviewParams): Promise<void> => {
+    await patchWithToken<WrappedDocuments>(
+        patchMyResumeReview(params.resumeReviewId),
+        params.tokenAcquirer,
+        {
+            state: 'canceled',
+        },
+        [Scope.UpdateMyResumeReviews],
+    ).catch(() => {
+        alert('Unable to download resume');
+    });
+};
+
+export default createAsyncThunk<void, CancelResumeReviewParams, AsyncThunkConfig>('reviewResume/cancelResumeReview', (params, thunkApi) => {
+    try {
+        return cancelMyResumeReview(params);
+    } catch (e) {
+        return thunkApi.rejectWithValue(e);
+    }
+});

--- a/www/src/routes/student/resumeReview/ResumeList.tsx
+++ b/www/src/routes/student/resumeReview/ResumeList.tsx
@@ -12,13 +12,15 @@ import ResumeReviewCard from './ResumeReviewCard';
 const ResumeList: FC = () => {
     const classes = useStyles();
 
-    const { resumeReviews, isLoading } = useStudentSelector((state) => state.resumeReview);
+    const { resumeReviews, isLoading, shouldReload } = useStudentSelector((state) => state.resumeReview);
     const { getAccessTokenSilently } = useAuth0();
     const dispatch = useStudentDispatch();
 
     useEffect(() => {
-        dispatch(getMyResumeReviews({ tokenAcquirer: getAccessTokenSilently }));
-    }, []);
+        if (shouldReload) {
+            dispatch(getMyResumeReviews({ tokenAcquirer: getAccessTokenSilently }));
+        }
+    }, [shouldReload]);
 
     const currentResumes = resumeReviews.filter((resumeReview) => resumeReview.state === 'seeking_reviewer' || resumeReview.state === 'reviewing');
     const currentResume = currentResumes.length > 0 ? currentResumes[0] : null;

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.test.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.test.tsx
@@ -1,9 +1,22 @@
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { shallow } from 'enzyme';
 import React from 'react';
+import { mocked } from 'ts-jest/utils';
 
+import { useStudentDispatch, useStudentSelector } from '../../../redux/substores/student/studentHooks';
 import testConstants from '../../../util/testConstants';
 import ResumeReviewCard from './ResumeReviewCard';
+
+jest.mock('../../../redux/substores/student/studentHooks');
+const mockUseStudentDispatch = mocked(useStudentDispatch, true);
+const mockUseStudentSelector = mocked(useStudentSelector, true);
+
+beforeEach(() => {
+    const mockStudentState = testConstants.studentState;
+    mockUseStudentSelector.mockImplementation((selector) => selector(mockStudentState));
+
+    mockUseStudentDispatch.mockReturnValue(jest.fn());
+});
 
 it.each(['cancelled', 'finished', 'reviewing', 'seeking_reviewer'])('displays the View button only when a review is not finished', (state) => {
     const mockResumeReview = testConstants.resumeReview1;

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -7,6 +7,8 @@ import clsx from 'clsx';
 import dateFormat from 'dateformat';
 import React, { FC, useState } from 'react';
 
+import { useStudentDispatch } from '../../../redux/substores/student/studentHooks';
+import cancelResumeReview from '../../../redux/substores/student/thunks/cancelResumeReview';
 import fetchWithToken from '../../../util/auth0/fetchWithToken';
 import TokenAcquirer from '../../../util/auth0/TokenAcquirer';
 import { getMyDocuments as getMyDocumentsEndpoint } from '../../../util/endpoints';
@@ -40,6 +42,7 @@ const downloadReviewedResume = async (resumeReviewId: string, tokenAcquirer: Tok
 const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeReviewCardProps) => {
     const classes = useStyles();
     const [isExpanded, setIsExpanded] = useState(false);
+    const dispatch = useStudentDispatch();
 
     const { getAccessTokenSilently } = useAuth0();
 
@@ -68,7 +71,15 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
                             View
                         </Button>
                     )}
-                    {resumeReview.state === 'seeking_reviewer' && <Button>Cancel review</Button>}
+                    {resumeReview.state === 'seeking_reviewer' && (
+                        <Button
+                            onClick={() => {
+                                dispatch(cancelResumeReview({ resumeReviewId: resumeReview.id, tokenAcquirer: getAccessTokenSilently }));
+                            }}
+                        >
+                            Cancel review
+                        </Button>
+                    )}
                 </Grid>
                 <Grid container alignItems='center' justify='flex-end' item xs={3}>
                     <Typography align='right'>{stateToDisplayNameMap.get(resumeReview.state)}</Typography>

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -64,6 +64,7 @@ const studentState: StudentState = {
         resumeReviews: [],
         isLoading: false,
         isUploading: false,
+        shouldReload: true,
     },
     resumeReviewViewer: {
         currentDocument: null,


### PR DESCRIPTION
# Overview

* Allow users to cancel resume review requests before they are claimed

# Changes

* Add `shouldReload` field, mimicking what's happening in volunteer app
* Add cancel resume review thunk which patches the resume review as cancelled

# Questions & Notes

* No tests because WE'RE RUNNING OUT OF TIME 😱

# Issue tracking

# Testing & Demo

Test in staging/dev. Clicking cancel should reload the list and move it to cancelled