### PR TITLE
Frontend code to fetch Calendly links

### DIFF
--- a/api/src/controllers/calendly/getCalendlys.ts
+++ b/api/src/controllers/calendly/getCalendlys.ts
@@ -3,7 +3,7 @@ import { CamelCasedProperties } from 'type-fest';
 import type * as s from 'zapatos/schema';
 
 import * as calendlyRepository from '../../repositories/calendlyRepository';
-import { decodeQueryToUser, manyToCamelCase } from '../../util/helper';
+import { decodeQueryToUser } from '../../util/helper';
 import controller from '../controllerUtil';
 import Validator, { beAValidUuid, beProperlyUriEncoded } from '../validation';
 
@@ -44,7 +44,18 @@ const getCalendlys = controller(async (req: Request<unknown, ResBody, unknown, R
 
     const calendlys = await calendlyRepository.get(id, interviewer);
 
-    res.status(200).json({ calendlys: manyToCamelCase(calendlys) });
+    res.status(200).json({
+        calendlys: calendlys.map((calendly) => {
+            return {
+                id: calendly.id,
+                link: calendly.link,
+                interviewer: calendly.interviewer,
+                interviewees: calendly.interviewees,
+                createdAt: calendly.created_at,
+                updatedAt: calendly.updated_at,
+            };
+        }),
+    });
 });
 
 export default getCalendlys;

--- a/www/src/redux/substores/student/slices/mockInterviewSlice.ts
+++ b/www/src/redux/substores/student/slices/mockInterviewSlice.ts
@@ -1,0 +1,32 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import getCalendlys from '../thunks/getCalendlys';
+
+type MockInterviewState = {
+    calendlyLink: string | undefined;
+    isLoading: boolean;
+};
+
+const initialState: MockInterviewState = {
+    calendlyLink: undefined,
+    isLoading: false,
+};
+
+export const mockInterviewSlice = createSlice({
+    name: 'mockInterview',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder.addCase(getCalendlys.pending, (state) => {
+            state.isLoading = true;
+        });
+        builder.addCase(getCalendlys.fulfilled, (state, action) => {
+            // Search for the interviewee in the fetched calendlys
+            state.calendlyLink = action.payload.calendlys.filter((calendly) => calendly.interviewees?.includes(action.payload.intervieweeId)).map((calendly) => calendly.link)[0];
+
+            state.isLoading = false;
+        });
+    },
+});
+
+export default mockInterviewSlice.reducer;

--- a/www/src/redux/substores/student/studentStore.ts
+++ b/www/src/redux/substores/student/studentStore.ts
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import mockInterviewReducer from './slices/mockInterviewSlice';
 import resumeReviewReducer from './slices/resumeReviewSlice';
 import resumeReviewViewerReducer from './slices/resumeReviewViewerSlice';
 import uploadResumeReducer from './slices/uploadResumeSlice';
@@ -9,6 +10,7 @@ const store = configureStore({
         resumeReview: resumeReviewReducer,
         resumeReviewViewer: resumeReviewViewerReducer,
         uploadResume: uploadResumeReducer,
+        mockInterview: mockInterviewReducer,
     },
 });
 

--- a/www/src/redux/substores/student/thunks/getCalendlys.tsx
+++ b/www/src/redux/substores/student/thunks/getCalendlys.tsx
@@ -1,0 +1,37 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import fetchWithToken from '../../../../util/auth0/fetchWithToken';
+import TokenAcquirer from '../../../../util/auth0/TokenAcquirer';
+import { getCalendlys as endpoint } from '../../../../util/endpoints';
+import { WrappedCalendlys } from '../../../../util/serverResponses';
+import { StudentDispatch, StudentState } from '../studentStore';
+
+export type GetCalendlysParams = {
+    tokenAcquirer: TokenAcquirer;
+    intervieweeId: string;
+};
+
+type AsyncThunkConfig = {
+    state: StudentState;
+    dispatch: StudentDispatch;
+    rejectValue: string;
+};
+
+type Output = WrappedCalendlys & { intervieweeId: string };
+
+export const getCalendlys = async (params: GetCalendlysParams): Promise<Output> => {
+    // TODO pass through scopes for auth
+    const calendlysResult = await fetchWithToken<WrappedCalendlys>(endpoint, params.tokenAcquirer, []).catch(() => {
+        throw new Error('Unable to fetch calendlys');
+    });
+
+    return calendlysResult ? { ...calendlysResult.data, intervieweeId: params.intervieweeId } : { calendlys: [], intervieweeId: '' };
+};
+
+export default createAsyncThunk<Output, GetCalendlysParams, AsyncThunkConfig>('mockInterview/getCalendlys', (params, thunkApi) => {
+    try {
+        return getCalendlys(params);
+    } catch (e) {
+        return thunkApi.rejectWithValue(e);
+    }
+});

--- a/www/src/redux/substores/volunteer/slices/mockInterviewSlice.ts
+++ b/www/src/redux/substores/volunteer/slices/mockInterviewSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 import getCalendlyLink from '../thunks/getCalendlyLink';
+import setCalendlyLink from '../thunks/setCalendlyLink';
 
 type MockInterviewState = {
     calendlyLink: string | undefined;
@@ -23,6 +24,13 @@ export const mockInterviewSlice = createSlice({
         builder.addCase(getCalendlyLink.fulfilled, (state, action) => {
             state.isLoading = false;
             state.calendlyLink = action.payload.calendlys[0]?.link;
+        });
+        builder.addCase(setCalendlyLink.pending, (state) => {
+            state.isLoading = true;
+        });
+        builder.addCase(setCalendlyLink.fulfilled, (state, action) => {
+            state.isLoading = false;
+            state.calendlyLink = action.payload?.calendly?.link;
         });
     },
 });

--- a/www/src/redux/substores/volunteer/slices/mockInterviewSlice.ts
+++ b/www/src/redux/substores/volunteer/slices/mockInterviewSlice.ts
@@ -1,0 +1,30 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import getCalendlyLink from '../thunks/getCalendlyLink';
+
+type MockInterviewState = {
+    calendlyLink: string | undefined;
+    isLoading: boolean;
+};
+
+const initialState: MockInterviewState = {
+    calendlyLink: undefined,
+    isLoading: false,
+};
+
+export const mockInterviewSlice = createSlice({
+    name: 'mockInterview',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder.addCase(getCalendlyLink.pending, (state) => {
+            state.isLoading = true;
+        });
+        builder.addCase(getCalendlyLink.fulfilled, (state, action) => {
+            state.isLoading = false;
+            state.calendlyLink = action.payload.calendlys[0]?.link;
+        });
+    },
+});
+
+export default mockInterviewSlice.reducer;

--- a/www/src/redux/substores/volunteer/thunks/getCalendlyLink.tsx
+++ b/www/src/redux/substores/volunteer/thunks/getCalendlyLink.tsx
@@ -1,0 +1,34 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import fetchWithToken from '../../../../util/auth0/fetchWithToken';
+import TokenAcquirer from '../../../../util/auth0/TokenAcquirer';
+import { getCalendlys } from '../../../../util/endpoints';
+import { WrappedCalendlys } from '../../../../util/serverResponses';
+import { VolunteerDispatch, VolunteerState } from '../volunteerStore';
+
+export type GetCalendlyLinkParams = {
+    tokenAcquirer: TokenAcquirer;
+    interviewerId: string;
+};
+
+type AsyncThunkConfig = {
+    state: VolunteerState;
+    dispatch: VolunteerDispatch;
+    rejectValue: string;
+};
+
+export const getCalendlyLink = async (params: GetCalendlyLinkParams): Promise<WrappedCalendlys> => {
+    // TODO pass through scopes for auth
+    const calendlysResult = await fetchWithToken<WrappedCalendlys>(getCalendlys, params.tokenAcquirer, [], { interviewer: params.interviewerId }).catch(() => {
+        throw new Error('Unable to fetch calendly link');
+    });
+    return calendlysResult?.data ?? { calendlys: [] };
+};
+
+export default createAsyncThunk<WrappedCalendlys, GetCalendlyLinkParams, AsyncThunkConfig>('mockInterview/getCalendlyLink', (params, thunkApi) => {
+    try {
+        return getCalendlyLink(params);
+    } catch (e) {
+        return thunkApi.rejectWithValue(e);
+    }
+});

--- a/www/src/redux/substores/volunteer/thunks/setCalendlyLink.tsx
+++ b/www/src/redux/substores/volunteer/thunks/setCalendlyLink.tsx
@@ -1,0 +1,36 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import postWithToken from '../../../../util/auth0/postWithToken';
+import TokenAcquirer from '../../../../util/auth0/TokenAcquirer';
+import { postCalendly } from '../../../../util/endpoints';
+import { WrappedCalendly } from '../../../../util/serverResponses';
+import { VolunteerDispatch, VolunteerState } from '../volunteerStore';
+
+export type SetCalendlyLinkParams = {
+    tokenAcquirer: TokenAcquirer;
+    interviewerId: string;
+    link: string;
+};
+
+type AsyncThunkConfig = {
+    state: VolunteerState;
+    dispatch: VolunteerDispatch;
+    rejectValue: string;
+};
+
+export const setCalendlyLink = async (params: SetCalendlyLinkParams): Promise<WrappedCalendly | undefined> => {
+    // TODO pass through scopes for auth
+    const calendlyResult = await postWithToken<{ interviewer: string; link: string }, WrappedCalendly>(postCalendly, params.tokenAcquirer, [], {
+        interviewer: params.interviewerId,
+        link: params.link,
+    });
+    return calendlyResult?.data;
+};
+
+export default createAsyncThunk<WrappedCalendly | undefined, SetCalendlyLinkParams, AsyncThunkConfig>('mockInterview/setCalendlyLink', (params, thunkApi) => {
+    try {
+        return setCalendlyLink(params);
+    } catch (e) {
+        return thunkApi.rejectWithValue(e);
+    }
+});

--- a/www/src/redux/substores/volunteer/volunteerStore.ts
+++ b/www/src/redux/substores/volunteer/volunteerStore.ts
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import mockInterviewReducer from './slices/mockInterviewSlice';
 import resumeReviewEditorReducer from './slices/resumeReviewEditorSlice';
 import resumeReviewReducer from './slices/resumeReviewSlice';
 
@@ -7,6 +8,7 @@ const store = configureStore({
     reducer: {
         resumeReview: resumeReviewReducer,
         resumeReviewEditor: resumeReviewEditorReducer,
+        mockInterview: mockInterviewReducer,
     },
 });
 

--- a/www/src/routes/student/MockInterview.tsx
+++ b/www/src/routes/student/MockInterview.tsx
@@ -1,15 +1,26 @@
+import { useAuth0 } from '@auth0/auth0-react';
 import { Grid, Link, Typography } from '@material-ui/core';
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 
 import GiveAvailabilityIcon from '../../assets/give_availability.svg';
+import LoadingOverlay from '../../components/LoadingOverlay';
+import { useStudentDispatch, useStudentSelector } from '../../redux/substores/student/studentHooks';
+import getCalendlys from '../../redux/substores/student/thunks/getCalendlys';
 
 const MockInterview: FC = () => {
-    // TODO hit backend to see if they have been paired with an interviewer yet
-    const calendlyLink = '';
+    const { calendlyLink, isLoading } = useStudentSelector((state) => state.mockInterview);
+    const dispatch = useStudentDispatch();
+    const { getAccessTokenSilently, user } = useAuth0();
+
+    useEffect(() => {
+        if (user?.sub !== undefined) {
+            dispatch(getCalendlys({ tokenAcquirer: getAccessTokenSilently, intervieweeId: user.sub }));
+        }
+    }, [user]);
 
     const notPaired = (
         <Grid container item xs={6} justify='center'>
-            <Typography>You haven&apos;t been paired with an interviewer yet. Check back again later.</Typography>
+            <Typography align='center'>You haven&apos;t been paired with an interviewer yet. Check back again later.</Typography>
         </Grid>
     );
 
@@ -23,6 +34,7 @@ const MockInterview: FC = () => {
 
     return (
         <div style={{ overflow: 'hidden' }}>
+            <LoadingOverlay open={isLoading} />
             <Grid container justify='center' alignItems='center' style={{ marginTop: '10px', minHeight: '75vh' }}>
                 <Grid container item justify='center'>
                     <Typography variant='h1'>Mock Interviews</Typography>
@@ -32,7 +44,7 @@ const MockInterview: FC = () => {
                         <img src={GiveAvailabilityIcon} />
                     </Grid>
                     <Grid container item xs={12} justify='center'>
-                        <Typography>You are allowed to book one mock interview with a randomly assigned interviewer.</Typography>
+                        <Typography align='center'>You are allowed to book one mock interview with a randomly assigned interviewer.</Typography>
                     </Grid>
                     {calendlyLink ? paired : notPaired}
                 </Grid>

--- a/www/src/routes/volunteer/MockInterview.tsx
+++ b/www/src/routes/volunteer/MockInterview.tsx
@@ -1,9 +1,11 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { Button, Grid, Link, makeStyles, TextField, Typography } from '@material-ui/core';
-import React, { FC, useEffect } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 
 import GiveAvailabilityIcon from '../../assets/give_availability.svg';
+import LoadingOverlay from '../../components/LoadingOverlay';
 import getCalendlyLink from '../../redux/substores/volunteer/thunks/getCalendlyLink';
+import setCalendlyLink from '../../redux/substores/volunteer/thunks/setCalendlyLink';
 import { useVolunteerDispatch, useVolunteerSelector } from '../../redux/substores/volunteer/volunteerHooks';
 
 const MockInterview: FC = () => {
@@ -11,6 +13,7 @@ const MockInterview: FC = () => {
     const { calendlyLink, isLoading } = useVolunteerSelector((state) => state.mockInterview);
     const dispatch = useVolunteerDispatch();
     const { getAccessTokenSilently, user } = useAuth0();
+    const [calendlyInput, setCalendlyInput] = useState<string>('');
 
     useEffect(() => {
         if (user?.sub !== undefined) {
@@ -26,8 +29,24 @@ const MockInterview: FC = () => {
                 </Typography>
             </Grid>
             <Grid container item xs={12} justify='center'>
-                <TextField id='outlined-basic' label='Calendly Link' variant='outlined' className={classes.textField} InputLabelProps={{ className: classes.label }} />
-                <Button variant='contained' color='primary' onClick={() => console.log('TODO')}>
+                <TextField
+                    id='outlined-basic'
+                    label='Calendly Link'
+                    variant='outlined'
+                    className={classes.textField}
+                    InputLabelProps={{ className: classes.label }}
+                    value={calendlyInput}
+                    onChange={(e) => setCalendlyInput(e.target.value)}
+                />
+                <Button
+                    variant='contained'
+                    color='primary'
+                    onClick={() => {
+                        if (user?.sub !== undefined) {
+                            dispatch(setCalendlyLink({ tokenAcquirer: getAccessTokenSilently, interviewerId: user.sub, link: calendlyInput }));
+                        }
+                    }}
+                >
                     Submit
                 </Button>
             </Grid>
@@ -45,6 +64,7 @@ const MockInterview: FC = () => {
 
     return (
         <div style={{ overflow: 'hidden' }}>
+            <LoadingOverlay open={isLoading} />
             <Grid container justify='center' alignItems='center' style={{ marginTop: '10px', minHeight: '75vh' }}>
                 <Grid container item justify='center'>
                     <Typography variant='h1'>Mock Interviews</Typography>

--- a/www/src/routes/volunteer/MockInterview.tsx
+++ b/www/src/routes/volunteer/MockInterview.tsx
@@ -1,13 +1,22 @@
+import { useAuth0 } from '@auth0/auth0-react';
 import { Button, Grid, Link, makeStyles, TextField, Typography } from '@material-ui/core';
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 
 import GiveAvailabilityIcon from '../../assets/give_availability.svg';
+import getCalendlyLink from '../../redux/substores/volunteer/thunks/getCalendlyLink';
+import { useVolunteerDispatch, useVolunteerSelector } from '../../redux/substores/volunteer/volunteerHooks';
 
 const MockInterview: FC = () => {
     const classes = useStyles();
+    const { calendlyLink, isLoading } = useVolunteerSelector((state) => state.mockInterview);
+    const dispatch = useVolunteerDispatch();
+    const { getAccessTokenSilently, user } = useAuth0();
 
-    // TODO hit backend to see if the volunteer has uploaded a Calendly link
-    const calendlyLink = '';
+    useEffect(() => {
+        if (user?.sub !== undefined) {
+            dispatch(getCalendlyLink({ tokenAcquirer: getAccessTokenSilently, interviewerId: user.sub }));
+        }
+    }, [user]);
 
     const submitLink = (
         <>

--- a/www/src/util/endpoints.ts
+++ b/www/src/util/endpoints.ts
@@ -3,6 +3,7 @@ import config from './config';
 export const getMe = `${config.server.endpoint}/api/v1/users/me`;
 export const getResumeReviews = `${config.server.endpoint}/api/v1/resume-reviews`;
 export const getUserRole = (userId: string): string => `${config.server.endpoint}/api/v1/users/${encodeURIComponent(userId)}/roles`;
+export const getCalendlys = `${config.server.endpoint}/api/v1/calendlys`;
 
 export const postUsers = `${config.server.endpoint}/api/v1/users`;
 

--- a/www/src/util/endpoints.ts
+++ b/www/src/util/endpoints.ts
@@ -6,6 +6,7 @@ export const getUserRole = (userId: string): string => `${config.server.endpoint
 export const getCalendlys = `${config.server.endpoint}/api/v1/calendlys`;
 
 export const postUsers = `${config.server.endpoint}/api/v1/users`;
+export const postCalendly = `${config.server.endpoint}/api/v1/calendlys`;
 
 export const postResumeReviews = `${config.server.endpoint}/api/v1/resume-reviews`;
 export const patchResumeReviews = (resumeReviewId: string): string => `${config.server.endpoint}/api/v1/resume-reviews/${resumeReviewId}`;

--- a/www/src/util/serverResponses.d.ts
+++ b/www/src/util/serverResponses.d.ts
@@ -81,6 +81,10 @@ export type Calendly = {
     updatedAt: string;
 };
 
+export type WrappedCalendly = {
+    calendly: Calendly;
+};
+
 export type WrappedCalendlys = {
     calendlys: Calendly[];
 };

--- a/www/src/util/serverResponses.d.ts
+++ b/www/src/util/serverResponses.d.ts
@@ -71,3 +71,16 @@ export type Role = {
 export type WrappedDocuments = {
     documents: Document[];
 };
+
+export type Calendly = {
+    id: string;
+    link: string;
+    interviewees?: string[];
+    interviewer: string;
+    createdAt: string;
+    updatedAt: string;
+};
+
+export type WrappedCalendlys = {
+    calendlys: Calendly[];
+};

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -92,6 +92,10 @@ const volunteerState: VolunteerState = {
         isLoading: false,
         isDone: false,
     },
+    mockInterview: {
+        calendlyLink: undefined,
+        isLoading: false,
+    },
 };
 
 export default { user1, resumeReview1, document1, globalState, studentState, volunteerState, studentRole };

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -75,6 +75,10 @@ const studentState: StudentState = {
         isLoading: false,
         isUploadComplete: null,
     },
+    mockInterview: {
+        calendlyLink: undefined,
+        isLoading: false,
+    },
 };
 
 const volunteerState: VolunteerState = {


### PR DESCRIPTION
# Overview

Frontend code to fetch Calendly links

# Changes

- 2 thunks for interviewer
- 1 thunk for student
- `manyToCamelCase` helper was modifying strings which was a problem b/c it prevented me from filtering on interviewee id. Instead of spending time investigating I just manually did the case transformation.

# Questions & Notes

Still need to do auth next.