### PR TITLE
Fix volunteer resume list reloading too fast

### DIFF
--- a/www/src/routes/volunteer/ResumeReview.tsx
+++ b/www/src/routes/volunteer/ResumeReview.tsx
@@ -21,13 +21,8 @@ const ResumeReview: FC = () => {
     const history = useHistory();
 
     useEffect(() => {
-        if (shouldReload) {
-            dispatch(getAvailableResumeReviews({ tokenAcquirer: getAccessTokenSilently }));
-        }
-    }, [shouldReload]);
-
-    useEffect(() => {
         if (user?.sub !== undefined && shouldReload) {
+            dispatch(getAvailableResumeReviews({ tokenAcquirer: getAccessTokenSilently }));
             dispatch(getReviewingResumeReviews({ tokenAcquirer: getAccessTokenSilently, userId: user.sub }));
         }
     }, [user, shouldReload]);

--- a/www/src/routes/volunteer/thunks/patchResumeReview.ts
+++ b/www/src/routes/volunteer/thunks/patchResumeReview.ts
@@ -48,7 +48,7 @@ export const patchResumeReview = async (params: PatchResumeReviewParams): Promis
 
 export default createAsyncThunk<void, PatchResumeReviewParams, AsyncThunkConfig>('reviewResume/patchResumeReview', (params, thunkApi) => {
     try {
-        patchResumeReview(params);
+        return patchResumeReview(params);
     } catch (e) {
         return thunkApi.rejectWithValue(e);
     }


### PR DESCRIPTION
# Overview

* Fix scenario when volunteer completes a resume review but is still listed under their currently reviewing section

# Changes

* Update the thunk to return the `Promise<void>` object
* Group the two fetches together since they're kind of bound to each other via shouldReload

# Questions & Notes

* Root cause was we didn't wait for the asynchronous function to finish so before patch resume review was done, it already triggered the `.fulfilled` event

# Issue tracking

Closes #231

# Testing & Demo

Completing a resume review in staging should now remove the entry in currently reviewing without a refresh