### PR TITLE
Close Dialog on switching roles

### DIFF
--- a/www/src/components/auth/UserProfile.test.tsx
+++ b/www/src/components/auth/UserProfile.test.tsx
@@ -3,14 +3,16 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import { mocked } from 'ts-jest/utils';
 
-import { useAppDispatch } from '../../redux/hooks';
+import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { openEditRolesDialog } from '../../redux/slices/userSlice';
 import { AppDispatch } from '../../redux/store';
+import { RootState } from '../../redux/store';
 import testConstants from '../../util/testConstants';
 import UserProfile from './UserProfile';
 
 jest.mock('../../redux/hooks');
 const useAppDispatchMock = mocked(useAppDispatch, true);
+const mockUseAppSelector = mocked(useAppSelector);
 
 jest.mock('@auth0/auth0-react');
 const useAuth0Mock = mocked(useAuth0, true);
@@ -18,10 +20,13 @@ const useAuth0Mock = mocked(useAuth0, true);
 describe('UserProfile', () => {
     let dispatchMock: jest.MockedFunction<AppDispatch>;
     let logoutMock: jest.MockedFunction<() => void>;
+    let mockGlobalStore: RootState;
 
     beforeEach(() => {
         dispatchMock = jest.fn();
         useAppDispatchMock.mockReturnValue(dispatchMock);
+        mockGlobalStore = testConstants.globalState;
+        mockUseAppSelector.mockImplementation((selector) => selector(mockGlobalStore));
 
         logoutMock = jest.fn();
         useAuth0Mock.mockReturnValue({
@@ -33,6 +38,8 @@ describe('UserProfile', () => {
     });
 
     it("extracts the correct ccid portion from the user's email", () => {
+        mockGlobalStore.user.isUserProfileOpen = true;
+        mockUseAppSelector.mockImplementation((selector) => selector(mockGlobalStore));
         const result = shallow(<UserProfile />);
 
         const ccidMenuItem = result.findWhere((component) => component.text() === `Signed in as: ${testConstants.user1.ccid}`).first();

--- a/www/src/components/auth/UserProfile.tsx
+++ b/www/src/components/auth/UserProfile.tsx
@@ -2,15 +2,15 @@ import { useAuth0 } from '@auth0/auth0-react';
 import { Divider, IconButton, Menu, MenuItem } from '@material-ui/core';
 import { fade, makeStyles } from '@material-ui/core/styles';
 import { AccountCircle } from '@material-ui/icons';
-import React, { FC, useRef, useState } from 'react';
+import React, { FC, useRef } from 'react';
 
-import { useAppDispatch } from '../../redux/hooks';
-import { openEditRolesDialog } from '../../redux/slices/userSlice';
+import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { closeUserProfileDialog, openEditRolesDialog, openUserProfileDiaog } from '../../redux/slices/userSlice';
 
 const UserProfile: FC = () => {
     const classes = useStyles();
     const userProfileIcon = useRef(null);
-    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const { isUserProfileOpen } = useAppSelector((state) => state.user);
     const { logout, user } = useAuth0();
     const ccid = user?.email?.split('@')[0] ?? '';
 
@@ -25,7 +25,7 @@ const UserProfile: FC = () => {
                 color='inherit'
                 ref={userProfileIcon}
                 onClick={() => {
-                    setIsMenuOpen(true);
+                    dispatch(openUserProfileDiaog());
                 }}
             >
                 <AccountCircle color='secondary' />
@@ -42,8 +42,8 @@ const UserProfile: FC = () => {
                     vertical: 'top',
                     horizontal: 'right',
                 }}
-                open={isMenuOpen}
-                onClose={() => setIsMenuOpen(false)}
+                open={isUserProfileOpen}
+                onClose={() => dispatch(closeUserProfileDialog())}
                 classes={{ paper: classes.menuPaper }}
             >
                 <MenuItem className={classes.menuItem}>Signed in as: {ccid}</MenuItem>

--- a/www/src/components/auth/UserProfile.tsx
+++ b/www/src/components/auth/UserProfile.tsx
@@ -5,7 +5,7 @@ import { AccountCircle } from '@material-ui/icons';
 import React, { FC, useRef } from 'react';
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
-import { closeUserProfileDialog, openEditRolesDialog, openUserProfileDiaog } from '../../redux/slices/userSlice';
+import { closeUserProfileDialog, openEditRolesDialog, openUserProfileDialog } from '../../redux/slices/userSlice';
 
 const UserProfile: FC = () => {
     const classes = useStyles();
@@ -25,7 +25,7 @@ const UserProfile: FC = () => {
                 color='inherit'
                 ref={userProfileIcon}
                 onClick={() => {
-                    dispatch(openUserProfileDiaog());
+                    dispatch(openUserProfileDialog());
                 }}
             >
                 <AccountCircle color='secondary' />

--- a/www/src/components/user/SettingsDialog.tsx
+++ b/www/src/components/user/SettingsDialog.tsx
@@ -12,6 +12,10 @@ const SettingsDialog: FC = () => {
 
     const { isSettingsDialogOpen, currentRole, roles } = useAppSelector((state) => state.user);
 
+    const handleOnChange = (role: string) => {
+        dispatch(closeEditRolesDialog());
+        dispatch(setCurrentRole(role));
+    };
     return (
         <Dialog onClose={() => dispatch(closeEditRolesDialog())} open={isSettingsDialogOpen}>
             <DialogTitle>Settings</DialogTitle>
@@ -22,7 +26,7 @@ const SettingsDialog: FC = () => {
                         control={
                             <Switch
                                 checked={currentRole === 'student'}
-                                onChange={() => dispatch(setCurrentRole('student'))}
+                                onChange={() => handleOnChange('student')}
                                 inputProps={{ 'aria-label': 'Toggle student role' }}
                                 disabled={!roles.includes('student')}
                             />
@@ -34,7 +38,7 @@ const SettingsDialog: FC = () => {
                         control={
                             <Switch
                                 checked={currentRole === 'volunteer'}
-                                onChange={() => dispatch(setCurrentRole('volunteer'))}
+                                onChange={() => handleOnChange('volunteer')}
                                 inputProps={{ 'aria-label': 'Toggle volunteer role' }}
                                 disabled={!roles.includes('reviewer' || !roles.includes('interviewer'))}
                             />
@@ -44,12 +48,7 @@ const SettingsDialog: FC = () => {
                     <FormControlLabel
                         labelPlacement='start'
                         control={
-                            <Switch
-                                checked={currentRole === 'admin'}
-                                onChange={() => dispatch(setCurrentRole('admin'))}
-                                inputProps={{ 'aria-label': 'Toggle admin role' }}
-                                disabled={!roles.includes('admin')}
-                            />
+                            <Switch checked={currentRole === 'admin'} onChange={() => handleOnChange('admin')} inputProps={{ 'aria-label': 'Toggle admin role' }} disabled={!roles.includes('admin')} />
                         }
                         label='Admin'
                     />

--- a/www/src/components/user/SettingsDialog.tsx
+++ b/www/src/components/user/SettingsDialog.tsx
@@ -5,7 +5,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import React, { FC } from 'react';
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
-import { closeEditRolesDialog, setCurrentRole } from '../../redux/slices/userSlice';
+import { closeEditRolesDialog, closeUserProfileDialog, setCurrentRole } from '../../redux/slices/userSlice';
 
 const SettingsDialog: FC = () => {
     const dispatch = useAppDispatch();
@@ -14,8 +14,10 @@ const SettingsDialog: FC = () => {
 
     const handleOnChange = (role: string) => {
         dispatch(closeEditRolesDialog());
+        dispatch(closeUserProfileDialog());
         dispatch(setCurrentRole(role));
     };
+
     return (
         <Dialog onClose={() => dispatch(closeEditRolesDialog())} open={isSettingsDialogOpen}>
             <DialogTitle>Settings</DialogTitle>

--- a/www/src/redux/slices/userSlice.ts
+++ b/www/src/redux/slices/userSlice.ts
@@ -37,7 +37,7 @@ export const userSlice = createSlice({
         closeUserProfileDialog(state) {
             state.isUserProfileOpen = false;
         },
-        openUserProfileDiaog(state) {
+        openUserProfileDialog(state) {
             state.isUserProfileOpen = true;
         },
     },
@@ -62,4 +62,4 @@ export const userSlice = createSlice({
 
 export default userSlice.reducer;
 
-export const { setCurrentRole, openEditRolesDialog, closeEditRolesDialog, closeUserProfileDialog, openUserProfileDiaog } = userSlice.actions;
+export const { setCurrentRole, openEditRolesDialog, closeEditRolesDialog, closeUserProfileDialog, openUserProfileDialog } = userSlice.actions;

--- a/www/src/redux/slices/userSlice.ts
+++ b/www/src/redux/slices/userSlice.ts
@@ -9,6 +9,7 @@ type UserState = {
     hasRegistered: boolean | null;
     isSettingsDialogOpen: boolean;
     isLoading: boolean;
+    isUserProfileOpen: boolean;
 };
 
 const initialState: UserState = {
@@ -17,6 +18,7 @@ const initialState: UserState = {
     hasRegistered: null,
     isSettingsDialogOpen: false,
     isLoading: false,
+    isUserProfileOpen: false,
 };
 
 export const userSlice = createSlice({
@@ -31,6 +33,12 @@ export const userSlice = createSlice({
         },
         closeEditRolesDialog(state) {
             state.isSettingsDialogOpen = false;
+        },
+        closeUserProfileDialog(state) {
+            state.isUserProfileOpen = false;
+        },
+        openUserProfileDiaog(state) {
+            state.isUserProfileOpen = true;
         },
     },
     extraReducers: (builder) => {
@@ -54,4 +62,4 @@ export const userSlice = createSlice({
 
 export default userSlice.reducer;
 
-export const { setCurrentRole, openEditRolesDialog, closeEditRolesDialog } = userSlice.actions;
+export const { setCurrentRole, openEditRolesDialog, closeEditRolesDialog, closeUserProfileDialog, openUserProfileDiaog } = userSlice.actions;

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -50,6 +50,7 @@ const globalState: RootState = {
         isLoading: false,
         hasRegistered: true,
         isSettingsDialogOpen: false,
+        isUserProfileOpen: false,
     },
     registerUser: {
         year: 0,


### PR DESCRIPTION
# Overview

What is the high-level goal of this PR? Is there any important context we should have?

# Changes

- Settings dialog closes when role is changed
- User Profile dialog also closes when role is changed 
    - Not 100% if we want this, I can easily rollback the commit if we want to keep the user profile dialog open when role changes

# Issue tracking

Closes #239 

# Testing & Demo

https://user-images.githubusercontent.com/32345990/132966815-75850cd6-3b30-450f-89af-a92ee558827f.mov
