### PR TITLE
General UI changes to settings 

### DIFF
--- a/www/src/components/user/SettingsDialog.tsx
+++ b/www/src/components/user/SettingsDialog.tsx
@@ -18,8 +18,13 @@ const SettingsDialog: FC = () => {
         dispatch(setCurrentRole(role));
     };
 
+    const handleOnClose = () => {
+        dispatch(closeEditRolesDialog());
+        dispatch(closeUserProfileDialog());
+    };
+
     return (
-        <Dialog onClose={() => dispatch(closeEditRolesDialog())} open={isSettingsDialogOpen}>
+        <Dialog onClose={handleOnClose} open={isSettingsDialogOpen}>
             <DialogTitle>Settings</DialogTitle>
             <DialogContent>
                 <FormGroup row>


### PR DESCRIPTION
# Overview

Closes the User Profile dialog when the Settings dialog is closed too 

# Changes

- Updated Settings.tsx to close the UserProfileDialog when settings is also closed 
- Set the `disabled` prop for the "ccid" menu item so that it's not clickable 

# Testing & Demo

![image](https://user-images.githubusercontent.com/32345990/132999313-72fdc3db-b6b3-479e-af03-c35e8c2b1f29.png)

https://user-images.githubusercontent.com/32345990/132999336-ec89e675-b9fd-4bfc-b593-0c867bbd745e.mov


