### PR TITLE
Fix PDF components to fill in rest of screen

### DIFF
--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { Container, CssBaseline, ThemeProvider } from '@material-ui/core';
+import { Box, CssBaseline, ThemeProvider } from '@material-ui/core';
 import React, { FC } from 'react';
 import { useEffect } from 'react';
 import { BrowserView, MobileView } from 'react-device-detect';
@@ -68,7 +68,7 @@ const App: FC = () => {
         <ThemeProvider theme={theme}>
             <CssBaseline />
             <LoadingOverlay open={isLoading || isAuth0Loading} />
-            <Container maxWidth={false} style={{ padding: 0, height: '100%' }}>
+            <Box display='flex' minHeight='100%' width='100%' flexDirection='column'>
                 <Router>
                     <Header sections={header_sections} title={COMPE_PLUS} />
                     <BrowserView renderWithFragment>
@@ -79,7 +79,7 @@ const App: FC = () => {
                         <MobileLanding />
                     </MobileView>
                 </Router>
-            </Container>
+            </Box>
         </ThemeProvider>
     );
 };

--- a/www/src/components/pdf/PDFViewer.tsx
+++ b/www/src/components/pdf/PDFViewer.tsx
@@ -19,17 +19,19 @@ export type PDFViewerProps = {
 } & React.ComponentProps<typeof Box>;
 
 const PDFViewer: FC<PDFViewerProps> = (props: PDFViewerProps) => {
+    const { filePromise, fileName, viewerConfig, saveOptions, onSave, ...remainingProps } = props;
+
     useEffect(() => {
         const viewSDKClient = new ViewSDKClient();
         viewSDKClient.ready().then(() => {
-            viewSDKClient.previewFileUsingFilePromise('adobe-dc-view', props.filePromise(), props.fileName, props.viewerConfig ?? {});
-            if (props.onSave !== undefined) {
-                viewSDKClient.onSave(props.onSave, props.saveOptions);
+            viewSDKClient.previewFileUsingFilePromise('adobe-dc-view', filePromise(), fileName, viewerConfig ?? {});
+            if (onSave !== undefined) {
+                viewSDKClient.onSave(onSave, saveOptions);
             }
         });
     }, []);
 
-    return <Box id='adobe-dc-view' height='100%' width='100%' {...props} />;
+    return <Box id='adobe-dc-view' height='100%' width='100%' {...remainingProps} />;
 };
 
 export default PDFViewer;

--- a/www/src/components/pdf/PDFViewer.tsx
+++ b/www/src/components/pdf/PDFViewer.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@material-ui/core';
+import { Box } from '@material-ui/core';
 import React, { FC } from 'react';
 import { useEffect } from 'react';
 
@@ -13,11 +13,10 @@ type ViewerConfig = {
 export type PDFViewerProps = {
     filePromise: () => Promise<ArrayBuffer>;
     fileName: string;
-    className?: string;
     viewerConfig?: ViewerConfig;
     saveOptions?: SaveOptions;
     onSave?: (arrayBuffer: ArrayBuffer) => void;
-};
+} & React.ComponentProps<typeof Box>;
 
 const PDFViewer: FC<PDFViewerProps> = (props: PDFViewerProps) => {
     useEffect(() => {
@@ -30,7 +29,7 @@ const PDFViewer: FC<PDFViewerProps> = (props: PDFViewerProps) => {
         });
     }, []);
 
-    return <Grid item id='adobe-dc-view' style={{ height: '100%', width: '100%' }} className={props.className} />;
+    return <Box id='adobe-dc-view' height='100%' width='100%' {...props} />;
 };
 
 export default PDFViewer;

--- a/www/src/routes/student/resumeReview/ResumeReviewViewer.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewViewer.tsx
@@ -1,6 +1,4 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { Grid } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -16,8 +14,6 @@ type ResumeReviewParams = {
 };
 
 const ResumeReviewViewer: React.FC = () => {
-    const classes = useStyles();
-
     const { resumeReviewId } = useParams<ResumeReviewParams>();
 
     const { currentDocument, isLoading } = useStudentSelector((state) => state.resumeReviewViewer);
@@ -42,33 +38,23 @@ const ResumeReviewViewer: React.FC = () => {
     };
 
     return (
-        <Grid container>
+        <>
             <LoadingOverlay open={isLoading} />
-            <Grid item xs={12}>
-                {currentDocument !== null && (
-                    <PDFViewer
-                        fileName={currentDocument.id}
-                        filePromise={filePromise}
-                        viewerConfig={{
-                            enableFormFilling: false,
-                            showAnnotationTools: false,
-                            showLeftHandPanel: false,
-                        }}
-                        className={classes.pdfContainer}
-                    />
-                )}
-            </Grid>
-        </Grid>
+            {currentDocument !== null && (
+                <PDFViewer
+                    fileName={currentDocument.id}
+                    filePromise={filePromise}
+                    viewerConfig={{
+                        enableFormFilling: false,
+                        showAnnotationTools: false,
+                        showLeftHandPanel: false,
+                    }}
+                    flex='1 1 auto'
+                    display='flex'
+                    flexDirection='column'
+                />
+            )}
+        </>
     );
 };
-
-const useStyles = makeStyles((theme) => ({
-    gridItem: {
-        padding: theme.spacing(1),
-    },
-    pdfContainer: {
-        minHeight: '60vh',
-    },
-}));
-
 export default ResumeReviewViewer;

--- a/www/src/routes/volunteer/ResumeReviewEditor.tsx
+++ b/www/src/routes/volunteer/ResumeReviewEditor.tsx
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { Button, Grid, Typography } from '@material-ui/core';
+import { Box, Button, Grid, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import DoneIcon from '@material-ui/icons/Done';
 import React, { useEffect } from 'react';
@@ -53,59 +53,63 @@ const ResumeReviewEditor: React.FC = () => {
     };
 
     return (
-        <Grid container>
+        <>
             <LoadingOverlay open={isLoading || (isResumeReviewPatched && !isDocumentPatched)} />
-            <Grid item xs={8} className={classes.gridItem}>
-                <Typography>{resumeReviewId}</Typography>
-            </Grid>
-            <Grid container item xs={4} justify='flex-end' className={classes.gridItem}>
-                <Button
-                    variant='contained'
-                    color='primary'
-                    endIcon={<DoneIcon />}
-                    onClick={() =>
+            <Box>
+                <Grid container>
+                    <Grid item xs={8} className={classes.gridItem}>
+                        <Typography>{resumeReviewId}</Typography>
+                    </Grid>
+                    <Grid container item xs={4} justify='flex-end' className={classes.gridItem}>
+                        <Button
+                            variant='contained'
+                            color='primary'
+                            endIcon={<DoneIcon />}
+                            onClick={() =>
+                                dispatch(
+                                    patchResumeReview({
+                                        resumeReviewId,
+                                        tokenAcquirer: getAccessTokenSilently,
+                                        userId: user?.sub ?? '',
+                                    }),
+                                )
+                            }
+                        >
+                            Complete review
+                        </Button>
+                    </Grid>
+                </Grid>
+            </Box>
+            {currentDocument !== null && (
+                <PDFViewer
+                    fileName={currentDocument.id}
+                    filePromise={filePromise}
+                    viewerConfig={{
+                        enableFormFilling: true,
+                        showAnnotationTools: true,
+                        showLeftHandPanel: true,
+                    }}
+                    onSave={(arrayBuffer) => {
+                        const base64Contents = arrayBufferToBase64(arrayBuffer);
                         dispatch(
-                            patchResumeReview({
+                            patchDocument({
+                                document: base64Contents,
+                                documentId: currentDocument?.id ?? '',
                                 resumeReviewId,
                                 tokenAcquirer: getAccessTokenSilently,
                                 userId: user?.sub ?? '',
                             }),
-                        )
-                    }
-                >
-                    Complete review
-                </Button>
-            </Grid>
-            <Grid container item xs={12}>
-                {currentDocument !== null && (
-                    <PDFViewer
-                        fileName={currentDocument.id}
-                        filePromise={filePromise}
-                        viewerConfig={{
-                            enableFormFilling: true,
-                            showAnnotationTools: true,
-                            showLeftHandPanel: true,
-                        }}
-                        onSave={(arrayBuffer) => {
-                            const base64Contents = arrayBufferToBase64(arrayBuffer);
-                            dispatch(
-                                patchDocument({
-                                    document: base64Contents,
-                                    documentId: currentDocument?.id ?? '',
-                                    resumeReviewId,
-                                    tokenAcquirer: getAccessTokenSilently,
-                                    userId: user?.sub ?? '',
-                                }),
-                            );
-                        }}
-                        saveOptions={{
-                            enableFocusPolling: true, // Auto-saves on focus loss
-                        }}
-                        className={classes.pdfContainer}
-                    />
-                )}
-            </Grid>
-        </Grid>
+                        );
+                    }}
+                    saveOptions={{
+                        enableFocusPolling: true, // Auto-saves on focus loss
+                    }}
+                    flex='1 1 auto'
+                    display='flex'
+                    flexDirection='column'
+                />
+            )}
+        </>
     );
 };
 
@@ -113,8 +117,8 @@ const useStyles = makeStyles((theme) => ({
     gridItem: {
         padding: theme.spacing(1),
     },
-    pdfContainer: {
-        minHeight: '60vh',
+    root: {
+        flex: '1 1',
     },
 }));
 

--- a/www/src/routes/volunteer/ResumeReviewEditor.tsx
+++ b/www/src/routes/volunteer/ResumeReviewEditor.tsx
@@ -24,10 +24,13 @@ const ResumeReviewEditor: React.FC = () => {
 
     const { resumeReviewId } = useParams<ResumeReviewParams>();
 
+    const { reviewingResumes } = useVolunteerSelector((state) => state.resumeReview);
     const { currentDocument, isLoading, isResumeReviewPatched, isDocumentPatched } = useVolunteerSelector((state) => state.resumeReviewEditor);
     const { getAccessTokenSilently, user } = useAuth0();
     const history = useHistory();
     const dispatch = useVolunteerDispatch();
+
+    const currentResumeReview = reviewingResumes.find((review) => review.id === resumeReviewId);
 
     useEffect(() => {
         dispatch(getMyDocuments({ tokenAcquirer: getAccessTokenSilently, resumeReviewId: resumeReviewId }));
@@ -57,8 +60,8 @@ const ResumeReviewEditor: React.FC = () => {
             <LoadingOverlay open={isLoading || (isResumeReviewPatched && !isDocumentPatched)} />
             <Box>
                 <Grid container>
-                    <Grid item xs={8} className={classes.gridItem}>
-                        <Typography>{resumeReviewId}</Typography>
+                    <Grid container alignItems='center' item xs={8} className={classes.gridItem}>
+                        {currentResumeReview && <Typography>{currentResumeReview?.reviewee.fullName}&apos;s resume</Typography>}
                     </Grid>
                     <Grid container item xs={4} justify='flex-end' className={classes.gridItem}>
                         <Button

--- a/www/src/routes/volunteer/ResumeReviewEditor.tsx
+++ b/www/src/routes/volunteer/ResumeReviewEditor.tsx
@@ -120,9 +120,6 @@ const useStyles = makeStyles((theme) => ({
     gridItem: {
         padding: theme.spacing(1),
     },
-    root: {
-        flex: '1 1',
-    },
 }));
 
 export default ResumeReviewEditor;

--- a/www/src/styles/index.css
+++ b/www/src/styles/index.css
@@ -19,3 +19,7 @@ body {
 #root {
     height: 100%;
 }
+
+#adobe-dc-view > iframe {
+    flex: 1 1 auto;
+}


### PR DESCRIPTION
# Overview

* Make reviewers enjoy their resume reviewing process more :)

# Changes

* Replace root container with a `flex` container (more on this later)
* Hijack the Adobe PDF's `iframe`, essentially adding `flex-grow: 1` to it so that it can fill the parent's div

# Questions & Notes

* `flex-grow` allows components to fill in the remaining `flex` parent
* I replaced the `resumeReviewId` with the reviewee's name, fetched from the resume review list
  * If the reviewer refreshes the editor page, they'll lose this name
  * We can fix it easily by fetching for the `resumeReviews` using the same thunk but let's do that in a separate PRR

# Issue tracking

Closes #240

# Testing & Demo

See in staging


https://user-images.githubusercontent.com/43416725/133196834-13c7c754-357d-4b0c-943b-8f028671f6fc.mov


