### PR TITLE
Refresh Button for Resume Reviews

### DIFF
--- a/www/src/redux/substores/volunteer/slices/resumeReviewSlice.ts
+++ b/www/src/redux/substores/volunteer/slices/resumeReviewSlice.ts
@@ -26,7 +26,11 @@ const initialState: ResumeReviewState = {
 export const resumeReviewSlice = createSlice({
     name: 'resumeReview',
     initialState,
-    reducers: {},
+    reducers: {
+        refreshResumeReviews(state) {
+            state.shouldReload = true;
+        },
+    },
     extraReducers: (builder) => {
         builder.addCase(getAvailableResumeReviews.pending, (state) => {
             state.availableIsLoading = true;
@@ -56,4 +60,5 @@ export const resumeReviewSlice = createSlice({
     },
 });
 
+export const { refreshResumeReviews } = resumeReviewSlice.actions;
 export default resumeReviewSlice.reducer;

--- a/www/src/routes/volunteer/ResumeReview.tsx
+++ b/www/src/routes/volunteer/ResumeReview.tsx
@@ -1,10 +1,12 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { CircularProgress, Grid, Typography } from '@material-ui/core';
+import { CircularProgress, Grid, IconButton, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import RefreshIcon from '@material-ui/icons/Refresh';
 import React, { FC, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import TitledPage from '../../components/TitledPage';
+import { refreshResumeReviews } from '../../redux/substores/volunteer/slices/resumeReviewSlice';
 import claimResumeReviews from '../../redux/substores/volunteer/thunks/claimResumeReviews';
 import getAvailableResumeReviews from '../../redux/substores/volunteer/thunks/getAvailableResumeReviews';
 import getReviewingResumeReviews from '../../redux/substores/volunteer/thunks/getReviewingResumeReviews';
@@ -12,7 +14,6 @@ import unclaimResumeReviews from '../../redux/substores/volunteer/thunks/unclaim
 import { useVolunteerDispatch, useVolunteerSelector } from '../../redux/substores/volunteer/volunteerHooks';
 import { ResumeReviewWithUserDetails as RRWUD } from '../../util/serverResponses';
 import ResumeReviewTable from './ResumeReviewTable';
-
 const ResumeReview: FC = () => {
     const { availableResumes, reviewingResumes, availableIsLoading, reviewingIsLoading, shouldReload } = useVolunteerSelector((state) => state.resumeReview);
     const { getAccessTokenSilently, user } = useAuth0();
@@ -51,7 +52,17 @@ const ResumeReview: FC = () => {
         <TitledPage title='Resume Review'>
             <Grid container justify='center' alignItems='center' direction='column'>
                 <Grid container justify='flex-start' alignItems='flex-start' direction='column'>
-                    <Typography variant='h2'>Currently Reviewing</Typography>
+                    <Grid container>
+                        <Grid item>
+                            <Typography variant='h2'>Currently Reviewing</Typography>
+                        </Grid>
+                        <Grid item alignItems='flex-end'>
+                            <IconButton onClick={() => dispatch(refreshResumeReviews())}>
+                                <RefreshIcon />
+                            </IconButton>
+                        </Grid>
+                    </Grid>
+
                     <Grid container justify='flex-start' alignItems='flex-start' className={classes.wrapper}>
                         {reviewingIsLoading && (
                             <Grid container justify='center' alignItems='flex-start'>

--- a/www/src/routes/volunteer/ResumeReview.tsx
+++ b/www/src/routes/volunteer/ResumeReview.tsx
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { Button, CircularProgress, Grid, IconButton, Typography } from '@material-ui/core';
+import { Button, CircularProgress, Grid, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import React, { FC, useEffect } from 'react';

--- a/www/src/routes/volunteer/ResumeReview.tsx
+++ b/www/src/routes/volunteer/ResumeReview.tsx
@@ -57,7 +57,13 @@ const ResumeReview: FC = () => {
                             <Typography variant='h2'>Currently Reviewing</Typography>
                         </Grid>
                         <Grid item xs={3} container justify='flex-end'>
-                            <Button onClick={() => dispatch(refreshResumeReviews())} variant='contained' color='primary' startIcon={<RefreshIcon />}>
+                            <Button
+                                disabled={availableIsLoading || reviewingIsLoading}
+                                onClick={() => dispatch(refreshResumeReviews())}
+                                variant='contained'
+                                color='primary'
+                                startIcon={<RefreshIcon />}
+                            >
                                 Refresh
                             </Button>
                         </Grid>

--- a/www/src/routes/volunteer/ResumeReview.tsx
+++ b/www/src/routes/volunteer/ResumeReview.tsx
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { CircularProgress, Grid, IconButton, Typography } from '@material-ui/core';
+import { Button, CircularProgress, Grid, IconButton, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import React, { FC, useEffect } from 'react';
@@ -53,13 +53,13 @@ const ResumeReview: FC = () => {
             <Grid container justify='center' alignItems='center' direction='column'>
                 <Grid container justify='flex-start' alignItems='flex-start' direction='column'>
                     <Grid container>
-                        <Grid item>
+                        <Grid item xs={9}>
                             <Typography variant='h2'>Currently Reviewing</Typography>
                         </Grid>
-                        <Grid item alignItems='flex-end'>
-                            <IconButton onClick={() => dispatch(refreshResumeReviews())}>
-                                <RefreshIcon />
-                            </IconButton>
+                        <Grid item xs={3} container justify='flex-end'>
+                            <Button onClick={() => dispatch(refreshResumeReviews())} variant='contained' color='primary' startIcon={<RefreshIcon />}>
+                                Refresh
+                            </Button>
                         </Grid>
                     </Grid>
 


### PR DESCRIPTION
# Overview

Added refresh button so that volunteers can easily see any changes to the available resumes table 

# Changes

- Created action to set `shouldReload` for resume review slice 
- Added button to resume review page 

Closes #258


# Testing & Demo

https://user-images.githubusercontent.com/32345990/133369151-16314ccb-0e7b-47d6-9629-4c2c7bc66053.mov

