### PR TITLE
Fix patch doc

### DIFF
--- a/api/src/controllers/document/patchMyDocument.test.ts
+++ b/api/src/controllers/document/patchMyDocument.test.ts
@@ -43,8 +43,9 @@ beforeEach(() => {
     };
     res = { status: jest.fn().mockReturnThis(), json: jest.fn().mockReturnThis() };
     next = jest.fn();
-    mockResumeReviewRepository.get.mockResolvedValueOnce([testConstants.resumeReview1]);
+    mockResumeReviewRepository.get.mockResolvedValue([testConstants.resumeReview1]);
     mockDocumentRepository.get.mockResolvedValue([testConstants.document1]);
+    mockDocumentRepository.getAssociatedToUser.mockResolvedValue([testConstants.document1]);
 });
 
 afterEach(() => {
@@ -157,7 +158,7 @@ it('catches error with base64Content', async () => {
 it('will not allow a user to modify a document not related to them', async () => {
     mockDocumentRepository.get.mockReset();
     mockDocumentRepository.get.mockResolvedValueOnce([testConstants.document1]);
-    mockDocumentRepository.get.mockResolvedValueOnce([]);
+    mockDocumentRepository.getAssociatedToUser.mockResolvedValueOnce([]);
     await patchMyDocument(req as Request<Params>, res as Response, next);
 
     expect(documentRepository.update).not.toBeCalled();

--- a/api/src/controllers/document/patchMyDocument.ts
+++ b/api/src/controllers/document/patchMyDocument.ts
@@ -49,7 +49,7 @@ const patchMyDocument = controller(async (req: Request<Params, unknown, ReqBody>
     await new ReqBodyValidator().validateAndThrow(req.body);
 
     // Make sure that the calling user is associated with the document
-    if ((await documentRepository.get(req.params.document, undefined, req.user.sub)).length === 0) {
+    if ((await documentRepository.getAssociatedToUser(req.user.sub, req.params.document, req.params.resumeReview)).length === 0) {
         throw new NotAuthorizedException();
     }
 


### PR DESCRIPTION
# Overview

* Allow reviewers to review resumes other than their own

# Changes

* Replace `documentRepository.get` with `documentRepository.getAssociatedToUser`

# Questions & Notes

* Previously verifying user association previously used the `userId` field which only allowed reviewers to review their own resume review (returning 403)
* Using `getAssociatedToUser` verifies that the volunteer is associated to the document via the resume review object

# Issue tracking

Closes #254

# Testing & Demo

1. In `dev` environment, comment [this line from `postUser.ts`](https://github.com/UAlbertaCompEClub/compe-plus/blob/97b93e916cfd8835365964edb3237a1e06dd2fec/api/src/controllers/user/postUser.ts#L24) and register your personal email.
2. Upload a resume for review using that personal email.
3. Review the resume using your ualberta email.
4. Verify that PATCH document returns 204.