### PR TITLE
Persist userRole between refreshes

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -35,6 +35,7 @@
                 "react-router-dom": "^5.2.0",
                 "react-scripts": "4.0.3",
                 "redux": "^4.1.0",
+                "redux-persist": "^6.0.0",
                 "typescript": "^4.2.4",
                 "validator": "^13.6.0",
                 "web-vitals": "^1.1.2"
@@ -16384,6 +16385,14 @@
             "integrity": "sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==",
             "dependencies": {
                 "@babel/runtime": "^7.9.2"
+            }
+        },
+        "node_modules/redux-persist": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+            "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+            "peerDependencies": {
+                "redux": ">4.0.0"
             }
         },
         "node_modules/redux-thunk": {
@@ -34072,6 +34081,12 @@
             "requires": {
                 "@babel/runtime": "^7.9.2"
             }
+        },
+        "redux-persist": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+            "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+            "requires": {}
         },
         "redux-thunk": {
             "version": "2.3.0",

--- a/www/package.json
+++ b/www/package.json
@@ -31,6 +31,7 @@
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.3",
         "redux": "^4.1.0",
+        "redux-persist": "^6.0.0",
         "typescript": "^4.2.4",
         "validator": "^13.6.0",
         "web-vitals": "^1.1.2"

--- a/www/src/index.tsx
+++ b/www/src/index.tsx
@@ -4,10 +4,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
+import { PersistGate } from 'redux-persist/integration/react';
 
 import App from './App';
+import LoadingOverlay from './components/LoadingOverlay';
 import Auth0ProviderWithHistory from './providers/Auth0ProviderWithHistory';
-import store from './redux/store';
+import store, { persistor } from './redux/store';
 import reportWebVitals from './reportWebVitals';
 
 ReactDOM.render(
@@ -15,7 +17,9 @@ ReactDOM.render(
         <BrowserRouter>
             <Auth0ProviderWithHistory>
                 <Provider store={store}>
-                    <App />
+                    <PersistGate loading={LoadingOverlay} persistor={persistor}>
+                        <App />
+                    </PersistGate>
                 </Provider>
             </Auth0ProviderWithHistory>
         </BrowserRouter>

--- a/www/src/redux/store.ts
+++ b/www/src/redux/store.ts
@@ -1,15 +1,36 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import { FLUSH, PAUSE, PERSIST, persistReducer, persistStore, PURGE, REGISTER, REHYDRATE } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 
 import registerUserReducer from './slices/registerUserSlice';
 import userReducer from './slices/userSlice';
 
-const store = configureStore({
-    reducer: {
-        user: userReducer,
-        registerUser: registerUserReducer,
-    },
+const persistConfig = {
+    key: 'root',
+    version: 1,
+    storage,
+};
+
+const rootReducer = combineReducers({
+    user: userReducer,
+    registerUser: registerUserReducer,
 });
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+const store = configureStore({
+    reducer: persistedReducer,
+    middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware({
+            serializableCheck: {
+                ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+            },
+        }),
+});
+
+export const persistor = persistStore(store);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
+
 export default store;

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -43,7 +43,7 @@ const studentRole: Role = {
     createdAt: '2021-06-14T06:09:19.373404+00:00',
 };
 
-const globalState: RootState = {
+const globalState: Partial<RootState> = {
     user: {
         roles: [],
         currentRole: '',


### PR DESCRIPTION
# Overview

* Allow volunteers to stay as volunteers in the event that they have to refresh a page

# Changes

* Install and integrate redux-persist

# Questions & Notes

* Data is stored in localStorage but the globalStore has no sensitive data other than year and program of the last registered user
* Eliminates the scenario where a student can see another student's resume when they switch back from reviewer to student in the editor

# Issue tracking

Closes #255

# Testing & Demo

As a volunteer, refresh the resume review page, you should stay as a volunteer