### PR TITLE
Prevent double claim of resume review

### DIFF
--- a/api/src/controllers/resumeReview/patchAllResumeReview.test.ts
+++ b/api/src/controllers/resumeReview/patchAllResumeReview.test.ts
@@ -34,7 +34,7 @@ beforeEach(() => {
     };
     res = { status: jest.fn().mockReturnThis(), end: jest.fn().mockReturnThis() };
     next = jest.fn();
-    mockResumeReviewRepository.get.mockResolvedValueOnce([testConstants.resumeReview1]);
+    mockResumeReviewRepository.get.mockResolvedValue([testConstants.resumeReview1]);
     mockUserRepository.get.mockResolvedValue([testConstants.user1]);
 });
 

--- a/api/src/controllers/resumeReview/patchMyResumeReview.test.ts
+++ b/api/src/controllers/resumeReview/patchMyResumeReview.test.ts
@@ -55,7 +55,6 @@ it('rejects non-uuid resume review', async () => {
 });
 
 it('rejects non-existent resume review', async () => {
-    mockResumeReviewRepository.get.mockReset();
     mockResumeReviewRepository.get.mockResolvedValueOnce([]);
     await patchMyResumeReview(req as Request<Params>, res as Response, next);
 
@@ -115,7 +114,6 @@ it('works with all fields', async () => {
 
 it('throws error when update fails', async () => {
     const err = new Error('');
-    mockResumeReviewRepository.update.mockReset();
     mockResumeReviewRepository.update.mockRejectedValueOnce(err);
 
     await patchMyResumeReview(req as Request<Params>, res as Response, next);
@@ -125,8 +123,12 @@ it('throws error when update fails', async () => {
 });
 
 it('throws not authorized when user does not match', async () => {
-    mockResumeReviewRepository.get.mockReset();
-    mockResumeReviewRepository.get.mockResolvedValueOnce([testConstants.resumeReview1]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    // Mock for validation
+    mockResumeReviewRepository.get.mockResolvedValueOnce([testConstants.resumeReview1]);
+    // Mock to check whether it's overriding another person's claim
+    mockResumeReviewRepository.get.mockResolvedValueOnce([testConstants.resumeReview1]);
+    // Mocks to check association to user
+    mockResumeReviewRepository.get.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
     await patchMyResumeReview(req as Request<Params>, res as Response, next);
 

--- a/api/src/repositories/resumeReviewRepository.ts
+++ b/api/src/repositories/resumeReviewRepository.ts
@@ -83,7 +83,8 @@ const update = async (id: string, reviewee?: string, reviewer?: string, state?: 
     if (reviewee !== undefined && reviewee !== null) {
         colOptions.reviewee_id = reviewee;
     }
-    if (reviewer !== undefined && reviewer !== null) {
+    // Allow the reviewer to be set to null
+    if (reviewer !== undefined) {
         colOptions.reviewer_id = reviewer;
     }
     if (state !== undefined && state !== null) {

--- a/api/src/util/testConstants.ts
+++ b/api/src/util/testConstants.ts
@@ -20,7 +20,7 @@ const resumeReview1: s.resume_reviews.JSONSelectable = {
     created_at: '2021-06-07T04:51:55.717971+00:00',
     updated_at: '2021-06-07T04:51:55.717971+00:00',
     reviewee_id: '319ffe68-cac5-470f-9186-33371300c38f',
-    reviewer_id: '97cf8fdc-884d-442a-ac71-9922b8f1ee5e',
+    reviewer_id: null,
 };
 
 const resumeReviewWithUserDetails1 = {


### PR DESCRIPTION
# Overview

Prevent double claim of resume review since UI won't refresh automatically when resumes are claimed.

# Testing & Demo

I want to test this on staging with someone else
