### PR TITLE
Fix 500 error for new users

### DIFF
--- a/api/src/controllers/user/getMe.ts
+++ b/api/src/controllers/user/getMe.ts
@@ -21,6 +21,7 @@ const getMe = controller(async (req: Request, res: Response<ResBody>): Promise<v
     const userExists = matches.length === 1;
     if (!userExists) {
         res.status(404).end();
+        return;
     }
 
     res.status(200).json({ user: toCamelCase(matches[0]) });


### PR DESCRIPTION
# Overview

* Fix server side 'Cannot set client headers after sending ... to client' error because we don't `return` after `.end()`

# Changes

* Add missing immediate `return` statement in `getMe.ts`

# Questions & Notes

* Other files that call `.end()` already have an implicit `return`

# Issue tracking

Closes #268

# Testing & Demo

* Open dev environment a user that's not registered in your local database