### PR TITLE
Armi/show errors

### DIFF
--- a/www/src/components/AlertError.tsx
+++ b/www/src/components/AlertError.tsx
@@ -1,0 +1,31 @@
+import { IconButton, Snackbar } from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import React, { useState } from 'react';
+
+type AlertErrorProps = {
+    errorMessage: string;
+};
+
+const AlertError: React.FC<AlertErrorProps> = ({ errorMessage }: AlertErrorProps) => {
+    const [isOpen, setIsOpen] = useState(true);
+
+    const handleClose = () => {
+        setIsOpen(false);
+    };
+    return (
+        <Snackbar
+            open={isOpen}
+            autoHideDuration={6_000}
+            onClose={() => setIsOpen(false)}
+            message={errorMessage}
+            anchorOrigin={{ horizontal: 'center', vertical: 'top' }}
+            action={
+                <IconButton size='small' aria-label='close' color='inherit' onClick={handleClose}>
+                    <CloseIcon fontSize='small' />
+                </IconButton>
+            }
+        />
+    );
+};
+
+export default AlertError;

--- a/www/src/components/AlertError.tsx
+++ b/www/src/components/AlertError.tsx
@@ -1,24 +1,31 @@
 import { IconButton, Snackbar } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 type AlertErrorProps = {
-    errorMessage: string;
+    errorMessage: string | null;
 };
 
 const AlertError: React.FC<AlertErrorProps> = ({ errorMessage }: AlertErrorProps) => {
-    const [isOpen, setIsOpen] = useState(true);
+    const [isOpen, setIsOpen] = useState(errorMessage !== null);
 
     const handleClose = () => {
         setIsOpen(false);
     };
+
+    useEffect(() => {
+        if (errorMessage !== null) {
+            setIsOpen(true);
+        }
+    }, [errorMessage]);
+
     return (
         <Snackbar
             open={isOpen}
             autoHideDuration={6_000}
             onClose={() => setIsOpen(false)}
             message={errorMessage}
-            anchorOrigin={{ horizontal: 'center', vertical: 'top' }}
+            anchorOrigin={{ horizontal: 'center', vertical: 'bottom' }}
             action={
                 <IconButton size='small' aria-label='close' color='inherit' onClick={handleClose}>
                     <CloseIcon fontSize='small' />

--- a/www/src/redux/substores/student/slices/resumeReviewSlice.ts
+++ b/www/src/redux/substores/student/slices/resumeReviewSlice.ts
@@ -10,6 +10,7 @@ type ResumeReviewState = {
     isLoading: boolean;
     isUploading: boolean;
     shouldReload: boolean;
+    errorMessage: string | null;
 };
 
 const initialState: ResumeReviewState = {
@@ -17,6 +18,7 @@ const initialState: ResumeReviewState = {
     isUploading: false,
     isLoading: false,
     shouldReload: true,
+    errorMessage: null,
 };
 
 export const resumeReviewSlice = createSlice({
@@ -38,6 +40,13 @@ export const resumeReviewSlice = createSlice({
             state.isLoading = false;
             state.resumeReviews = action.payload.resumeReviews;
             state.shouldReload = false;
+        });
+        builder.addCase(getMyResumeReviews.rejected, (state, action) => {
+            state.isLoading = false;
+            if (action.payload === undefined) {
+                return;
+            }
+            state.errorMessage = action.payload;
         });
         builder.addCase(cancelMyResumeReview.pending, (state) => {
             state.isLoading = true;

--- a/www/src/redux/substores/student/thunks/getMyResumeReviews.ts
+++ b/www/src/redux/substores/student/thunks/getMyResumeReviews.ts
@@ -24,10 +24,10 @@ export const getMyResumeReviews = async (params: InitiateResumeReviewParams): Pr
     return resumeReviewResult?.data ?? { resumeReviews: [] };
 };
 
-export default createAsyncThunk<WrappedResumeReviewsWithDetails, InitiateResumeReviewParams, AsyncThunkConfig>('resumeReview/getMyResumeReviews', (params, thunkApi) => {
+export default createAsyncThunk<WrappedResumeReviewsWithDetails, InitiateResumeReviewParams, AsyncThunkConfig>('resumeReview/getMyResumeReviews', async (params, thunkApi) => {
     try {
-        return getMyResumeReviews(params);
+        return await getMyResumeReviews(params);
     } catch (e) {
-        return thunkApi.rejectWithValue(e);
+        return thunkApi.rejectWithValue(e.message);
     }
 });

--- a/www/src/routes/student/ResumeReview.tsx
+++ b/www/src/routes/student/ResumeReview.tsx
@@ -1,16 +1,18 @@
 import { Grid } from '@material-ui/core';
 import React, { FC } from 'react';
 
+import AlertError from '../../components/AlertError';
 import TitledPage from '../../components/TitledPage';
 import { useStudentSelector } from '../../redux/substores/student/studentHooks';
 import ResumeList from './resumeReview/ResumeList';
 import UploadResume from './resumeReview/UploadResume';
 
 const ResumeReview: FC = () => {
-    const { isUploading } = useStudentSelector((state) => state.resumeReview);
+    const { isUploading, errorMessage } = useStudentSelector((state) => state.resumeReview);
 
     return (
         <TitledPage title='Resume Review'>
+            <AlertError errorMessage={errorMessage} />
             <Grid container item justify='center'>
                 {isUploading ? <UploadResume /> : <ResumeList />}
             </Grid>

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -66,6 +66,7 @@ const studentState: StudentState = {
         isLoading: false,
         isUploading: false,
         shouldReload: true,
+        errorMessage: null,
     },
     resumeReviewViewer: {
         currentDocument: null,


### PR DESCRIPTION
# Overview

* Set an example on how to display error messages on failed API calls
* Set example for failed resume reviews

# Changes

* Create `AlertError` component to display the error messages

# Questions & Notes

* One page/slice will have one `AlertError`
* I tried multiple variants and couldn't set-up a global error handler because our logic is in thunks not the React DOM itself. In case you're curious what I tried:
  * Added new error slice on the global store -- can't get `.rejected` events from thunks other than those in global store because of the async thunk configs
  * Custom react context -- couldn't get the events to fire consistently (or I did a poor way of implementing it)

# Issue tracking


# Testing & Demo

* Update `api/src/controllers/resumeReview/getMyResumeReviews.ts`'s body  to 
```ts
    res.status(404).end();

https://user-images.githubusercontent.com/43416725/133945483-7e2a9941-1f52-4dfc-8519-077109efaff7.mov


    return;
```
* Refresh the resume list page as a student
