### PR TITLE
Prevent create/update endpoints in backend when user has not agreed to TOS

### DIFF
--- a/api/src/controllers/middleware.test.ts
+++ b/api/src/controllers/middleware.test.ts
@@ -161,7 +161,7 @@ describe('authorizeAndFallthrough middleware', () => {
     });
 });
 
-describe('registeredUser middleware', () => {
+describe('checkTOSAgreement middleware', () => {
     let mockRequest: Partial<Request> = {};
     let mockResponse: Partial<Response>;
     let nextFunction: NextFunction;
@@ -181,7 +181,7 @@ describe('registeredUser middleware', () => {
     it('throws when user does not exist', async () => {
         mockUserRepository.get.mockResolvedValueOnce([]);
 
-        await middleware.registeredUser()(mockRequest as Request, mockResponse as Response, nextFunction);
+        await middleware.checkTOSAgreement()(mockRequest as Request, mockResponse as Response, nextFunction);
 
         expect(nextFunction).toBeCalledWith(
             new NotAuthorizedException({
@@ -194,7 +194,7 @@ describe('registeredUser middleware', () => {
         mockUser.has_agreed_to_terms_of_service = false;
         mockUserRepository.get.mockResolvedValueOnce([mockUser]);
 
-        await middleware.registeredUser()(mockRequest as Request, mockResponse as Response, nextFunction);
+        await middleware.checkTOSAgreement()(mockRequest as Request, mockResponse as Response, nextFunction);
 
         expect(nextFunction).toBeCalledWith(
             new NotAuthorizedException({
@@ -207,7 +207,7 @@ describe('registeredUser middleware', () => {
         mockUser.has_agreed_to_terms_of_service = true;
         mockUserRepository.get.mockResolvedValueOnce([mockUser]);
 
-        await middleware.registeredUser()(mockRequest as Request, mockResponse as Response, nextFunction);
+        await middleware.checkTOSAgreement()(mockRequest as Request, mockResponse as Response, nextFunction);
 
         expect(nextFunction).not.toBeCalledWith(
             new NotAuthorizedException({

--- a/api/src/controllers/middleware.test.ts
+++ b/api/src/controllers/middleware.test.ts
@@ -5,10 +5,15 @@ import { mocked } from 'ts-jest/utils';
 import NotAuthenticatedException from '../exceptions/NotAuthenticatedException';
 import NotAuthorizedException from '../exceptions/NotAuthorizedException';
 import NotFoundException from '../exceptions/NotFoundException';
+import * as userRepository from '../repositories/userRepository';
 import Scope from '../types/scopes';
 import config from '../util/config';
 import logger from '../util/logger';
+import testConstants from '../util/testConstants';
 import middleware from './middleware';
+
+jest.mock('../repositories/userRepository');
+const mockUserRepository = mocked(userRepository, true);
 
 describe('notFound middleware', () => {
     const mockRequest: Partial<Request> = {};
@@ -153,6 +158,62 @@ describe('authorizeAndFallthrough middleware', () => {
         e.message = 'Insufficient scope';
         middleware.authorizeAndFallThrough(Scope.CreateDocuments)[1](e, mockRequest as Request, mockResponse as Response, nextFunction);
         expect(nextFunction).toBeCalledWith('route');
+    });
+});
+
+describe('registeredUser middleware', () => {
+    let mockRequest: Partial<Request> = {};
+    let mockResponse: Partial<Response>;
+    let nextFunction: NextFunction;
+    let mockUser = testConstants.user1;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        mockRequest = {
+            user: {
+                sub: testConstants.user1.id,
+            },
+        };
+        nextFunction = jest.fn();
+        mockUser = testConstants.user1;
+    });
+
+    it('throws when user does not exist', async () => {
+        mockUserRepository.get.mockResolvedValueOnce([]);
+
+        await middleware.registeredUser()(mockRequest as Request, mockResponse as Response, nextFunction);
+
+        expect(nextFunction).toBeCalledWith(
+            new NotAuthorizedException({
+                reason: 'User has not agreed to terms of service',
+            }),
+        );
+    });
+
+    it("throws when user has not agreed to CompE+'s terms of service", async () => {
+        mockUser.has_agreed_to_terms_of_service = false;
+        mockUserRepository.get.mockResolvedValueOnce([mockUser]);
+
+        await middleware.registeredUser()(mockRequest as Request, mockResponse as Response, nextFunction);
+
+        expect(nextFunction).toBeCalledWith(
+            new NotAuthorizedException({
+                reason: 'User has not agreed to terms of service',
+            }),
+        );
+    });
+
+    it("doesn't throw when user has agreed to CompE+'s terms of service", async () => {
+        mockUser.has_agreed_to_terms_of_service = true;
+        mockUserRepository.get.mockResolvedValueOnce([mockUser]);
+
+        await middleware.registeredUser()(mockRequest as Request, mockResponse as Response, nextFunction);
+
+        expect(nextFunction).not.toBeCalledWith(
+            new NotAuthorizedException({
+                reason: 'User has not agreed to terms of service',
+            }),
+        );
     });
 });
 

--- a/api/src/controllers/middleware.ts
+++ b/api/src/controllers/middleware.ts
@@ -139,7 +139,7 @@ function authorizeAndFallThrough(scope: Scope): ErrHandledMiddleware {
  * Returns the middleware that will ensure the user is registered in our database and has agreed to our terms of service.
  * @returns registeredUser middleware.
  */
-function registeredUser(): AsyncMiddleware {
+function checkTOSAgreement(): AsyncMiddleware {
     return async (req: Request, res: Response, next: NextFunction) => {
         const matches = await userRepository.get(req.user.sub);
         if (!(matches.length === 1 && matches[0].has_agreed_to_terms_of_service)) {
@@ -191,7 +191,7 @@ export default {
     notFound,
     errorHandler,
     authenticate,
-    registeredUser,
+    checkTOSAgreement,
     authorize,
     authorizeAndFallThrough,
     jsonParser,

--- a/api/src/controllers/middleware.ts
+++ b/api/src/controllers/middleware.ts
@@ -135,6 +135,10 @@ function authorizeAndFallThrough(scope: Scope): ErrHandledMiddleware {
     return [checkAuthorization, errorHandler];
 }
 
+/**
+ * Returns the middleware that will ensure the user is registered in our database and has agreed to our terms of service.
+ * @returns registeredUser middleware.
+ */
 function registeredUser(): AsyncMiddleware {
     return async (req: Request, res: Response, next: NextFunction) => {
         const matches = await userRepository.get(req.user.sub);

--- a/api/src/exceptions/NotAuthorizedException.ts
+++ b/api/src/exceptions/NotAuthorizedException.ts
@@ -7,8 +7,8 @@ class NotAuthorizedException extends HttpException {
     /**
      * Create an NotAuthorizedException.
      */
-    constructor() {
-        super(403, 'Not authorized');
+    constructor(details?: Record<string, unknown>) {
+        super(403, 'Not authorized', details);
         Object.setPrototypeOf(this, NotAuthorizedException.prototype);
     }
 }

--- a/api/src/routes/calendlyRoutes.ts
+++ b/api/src/routes/calendlyRoutes.ts
@@ -7,7 +7,7 @@ import Scope from '../types/scopes';
 export const router = express.Router();
 
 router.get('/calendlys', middleware.authorize(Scope.ReadCalendlys), controller.getCalendlys);
-router.post('/calendlys/', middleware.authorize(Scope.CreateCalendlys), controller.postCalendly);
-router.patch('/calendlys/:calendly', middleware.authorize(Scope.UpdateCalendlys), controller.patchCalendly);
+router.post('/calendlys/', middleware.authorize(Scope.CreateCalendlys), middleware.checkTOSAgreement(), controller.postCalendly);
+router.patch('/calendlys/:calendly', middleware.authorize(Scope.UpdateCalendlys), middleware.checkTOSAgreement(), controller.patchCalendly);
 
 export default router;

--- a/api/src/routes/documentRoutes.ts
+++ b/api/src/routes/documentRoutes.ts
@@ -9,9 +9,9 @@ export const router = express.Router();
 router.get('/resume-reviews/:resumeReview/documents', middleware.authorizeAndFallThrough(Scope.ReadAllDocuments), controller.getAllDocuments);
 router.get('/resume-reviews/:resumeReview/documents', middleware.authorize(Scope.ReadMyDocuments), controller.getMyDocuments);
 
-router.post('/resume-reviews/:resumeReview/documents', middleware.authorize(Scope.CreateDocuments), controller.postDocument);
+router.post('/resume-reviews/:resumeReview/documents', middleware.authorize(Scope.CreateDocuments), middleware.checkTOSAgreement(), controller.postDocument);
 
-router.patch('/resume-reviews/:resumeReview/documents/:document', middleware.authorizeAndFallThrough(Scope.UpdateAllDocuments), controller.patchAllDocument);
-router.patch('/resume-reviews/:resumeReview/documents/:document', middleware.authorize(Scope.UpdateMyDocuments), controller.patchMyDocument);
+router.patch('/resume-reviews/:resumeReview/documents/:document', middleware.authorizeAndFallThrough(Scope.UpdateAllDocuments), middleware.checkTOSAgreement(), controller.patchAllDocument);
+router.patch('/resume-reviews/:resumeReview/documents/:document', middleware.authorize(Scope.UpdateMyDocuments), middleware.checkTOSAgreement(), controller.patchMyDocument);
 
 export default router;

--- a/api/src/routes/resumeReviewRoutes.ts
+++ b/api/src/routes/resumeReviewRoutes.ts
@@ -9,7 +9,7 @@ export const router = express.Router();
 router.get('/resume-reviews', middleware.authorizeAndFallThrough(Scope.ReadAllResumeReviews), controller.getAllResumeReviews);
 router.get('/resume-reviews', middleware.authorize(Scope.ReadMyResumeReviews), controller.getMyResumeReviews);
 
-router.post('/resume-reviews', middleware.authorize(Scope.CreateResumeReviews), controller.postResumeReview);
+router.post('/resume-reviews', middleware.authorize(Scope.CreateResumeReviews), middleware.checkTOSAgreement(), controller.postResumeReview);
 
 router.patch('/resume-reviews/:resumeReview', middleware.authorizeAndFallThrough(Scope.UpdateAllResumeReviews), controller.patchAllResumeReview);
 router.patch('/resume-reviews/:resumeReview', middleware.authorize(Scope.UpdateMyResumeReviews), controller.patchMyResumeReview);

--- a/api/src/routes/resumeReviewRoutes.ts
+++ b/api/src/routes/resumeReviewRoutes.ts
@@ -11,7 +11,7 @@ router.get('/resume-reviews', middleware.authorize(Scope.ReadMyResumeReviews), c
 
 router.post('/resume-reviews', middleware.authorize(Scope.CreateResumeReviews), middleware.checkTOSAgreement(), controller.postResumeReview);
 
-router.patch('/resume-reviews/:resumeReview', middleware.authorizeAndFallThrough(Scope.UpdateAllResumeReviews), controller.patchAllResumeReview);
-router.patch('/resume-reviews/:resumeReview', middleware.authorize(Scope.UpdateMyResumeReviews), controller.patchMyResumeReview);
+router.patch('/resume-reviews/:resumeReview', middleware.authorizeAndFallThrough(Scope.UpdateAllResumeReviews), middleware.checkTOSAgreement(), controller.patchAllResumeReview);
+router.patch('/resume-reviews/:resumeReview', middleware.authorize(Scope.UpdateMyResumeReviews), middleware.checkTOSAgreement(), controller.patchMyResumeReview);
 
 export default router;


### PR DESCRIPTION
# Overview

Prevent users from interacting with CompE+'s backend when they have not read the terms of service

# Changes

Created a TOS checker middleware that's applied to all create/update endpoints

# Questions & Notes

This is our last line of defence, I'll be disabling the buttons and displaying the error messages on the front end in another PR. 

Merging this PR does not pose any risk because changes are only done in backend and needs to be promoted to production in heroku before it impacts anyone.

# Issue tracking

Part of #278

# Testing & Demo

Using the new schema try posting a resume for review without having agreed to the terms of service 

![image](https://user-images.githubusercontent.com/43416725/141657637-d1923a03-85df-4df9-83d6-53afc6f47adb.png)
![image](https://user-images.githubusercontent.com/43416725/141657640-64c68a42-15c2-4264-be90-7f4fb1be697e.png)

You'll get an infinite loading spinner at the moment but I plan to display an error message where it educates users on where they can click to read/agree the TOS