### PR TITLE
Disable front end interactions for users that have not agreed to TOS

### DIFF
--- a/www/src/App.test.tsx
+++ b/www/src/App.test.tsx
@@ -37,13 +37,6 @@ const mockFetchUserInfo = mocked(fetchUserInfo);
 jest.mock('./redux/thunks/getUserRole');
 const mockGetUserRole = mocked(getUserRole);
 
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useHistory: () => ({
-        push: jest.fn(),
-    }),
-}));
-
 describe('App', () => {
     let mockGlobalStore: RootState;
     let mockDispatch: jest.MockedFunction<AppDispatch>;

--- a/www/src/contexts/UserContext.tsx
+++ b/www/src/contexts/UserContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+type SubsetUserState = {
+    roles: string[];
+    currentRole: string;
+    hasAgreedToTermsOfService: boolean | null;
+};
+
+const UserContext = createContext<SubsetUserState | null>(null);
+
+export default UserContext;

--- a/www/src/contexts/UserContext.tsx
+++ b/www/src/contexts/UserContext.tsx
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
-type SubsetUserState = {
+export type SubsetUserState = {
     roles: string[];
     currentRole: string;
     hasAgreedToTermsOfService: boolean | null;

--- a/www/src/hooks/useUserContext.tsx
+++ b/www/src/hooks/useUserContext.tsx
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import UserContext, { SubsetUserState } from '../contexts/UserContext';
+
+const useUserContext = (): SubsetUserState | null => useContext(UserContext);
+
+export default useUserContext;

--- a/www/src/index.tsx
+++ b/www/src/index.tsx
@@ -9,6 +9,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 import App from './App';
 import LoadingOverlay from './components/LoadingOverlay';
 import Auth0ProviderWithHistory from './providers/Auth0ProviderWithHistory';
+import UserProvider from './providers/UserProvider';
 import store, { persistor } from './redux/store';
 import reportWebVitals from './reportWebVitals';
 
@@ -18,7 +19,9 @@ ReactDOM.render(
             <Auth0ProviderWithHistory>
                 <Provider store={store}>
                     <PersistGate loading={LoadingOverlay} persistor={persistor}>
-                        <App />
+                        <UserProvider>
+                            <App />
+                        </UserProvider>
                     </PersistGate>
                 </Provider>
             </Auth0ProviderWithHistory>

--- a/www/src/providers/UserProvider.tsx
+++ b/www/src/providers/UserProvider.tsx
@@ -1,0 +1,16 @@
+import React, { FC, ReactNode } from 'react';
+
+import UserContext from '../contexts/UserContext';
+import { useAppSelector } from '../redux/hooks';
+
+type UserProviderProps = {
+    children: ReactNode;
+};
+
+const UserProvider: FC<UserProviderProps> = ({ children }: UserProviderProps) => {
+    const user = useAppSelector((state) => state.user);
+
+    return <UserContext.Provider value={user}>{children}</UserContext.Provider>;
+};
+
+export default UserProvider;

--- a/www/src/routes/student/MockInterview.test.tsx
+++ b/www/src/routes/student/MockInterview.test.tsx
@@ -1,0 +1,31 @@
+import Link from '@material-ui/core/Link';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { mocked } from 'ts-jest/utils';
+
+import { SubsetUserState } from '../../contexts/UserContext';
+import useUserContext from '../../hooks/useUserContext';
+import { useStudentSelector } from '../../redux/substores/student/studentHooks';
+import testConstants from '../../util/testConstants';
+import MockInterview from './MockInterview';
+
+jest.mock('../../hooks/useUserContext');
+const mockUseUserContext = mocked(useUserContext, true);
+
+jest.mock('../../redux/substores/student/studentHooks');
+const mockUseStudentSelector = mocked(useStudentSelector, true);
+
+describe('MockInterview', () => {
+    beforeEach(() => {
+        mockUseStudentSelector.mockReturnValue(testConstants.studentState);
+    });
+
+    it('hides the calendly link when user has not agreed to terms of service', () => {
+        mockUseUserContext.mockReturnValueOnce({
+            hasAgreedToTermsOfService: false,
+        } as SubsetUserState);
+
+        const result = shallow(<MockInterview />);
+        expect(result.find(Link)).toHaveLength(0);
+    });
+});

--- a/www/src/routes/student/MockInterview.tsx
+++ b/www/src/routes/student/MockInterview.tsx
@@ -1,10 +1,10 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { Grid, Link, Typography } from '@material-ui/core';
-import React, { FC, useContext, useEffect } from 'react';
+import React, { FC, useEffect } from 'react';
 
 import GiveAvailabilityIcon from '../../assets/give_availability.svg';
 import LoadingOverlay from '../../components/LoadingOverlay';
-import UserContext from '../../contexts/UserContext';
+import useUserContext from '../../hooks/useUserContext';
 import { useStudentDispatch, useStudentSelector } from '../../redux/substores/student/studentHooks';
 import getCalendlys from '../../redux/substores/student/thunks/getCalendlys';
 
@@ -12,7 +12,7 @@ const MockInterview: FC = () => {
     const { calendlyLink, isLoading } = useStudentSelector((state) => state.mockInterview);
     const dispatch = useStudentDispatch();
     const { getAccessTokenSilently, user } = useAuth0();
-    const userContext = useContext(UserContext);
+    const userContext = useUserContext();
 
     useEffect(() => {
         if (user?.sub !== undefined) {

--- a/www/src/routes/student/MockInterview.tsx
+++ b/www/src/routes/student/MockInterview.tsx
@@ -1,9 +1,10 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { Grid, Link, Typography } from '@material-ui/core';
-import React, { FC, useEffect } from 'react';
+import React, { FC, useContext, useEffect } from 'react';
 
 import GiveAvailabilityIcon from '../../assets/give_availability.svg';
 import LoadingOverlay from '../../components/LoadingOverlay';
+import UserContext from '../../contexts/UserContext';
 import { useStudentDispatch, useStudentSelector } from '../../redux/substores/student/studentHooks';
 import getCalendlys from '../../redux/substores/student/thunks/getCalendlys';
 
@@ -11,12 +12,15 @@ const MockInterview: FC = () => {
     const { calendlyLink, isLoading } = useStudentSelector((state) => state.mockInterview);
     const dispatch = useStudentDispatch();
     const { getAccessTokenSilently, user } = useAuth0();
+    const userContext = useContext(UserContext);
 
     useEffect(() => {
         if (user?.sub !== undefined) {
             dispatch(getCalendlys({ tokenAcquirer: getAccessTokenSilently, intervieweeId: user.sub }));
         }
     }, [user]);
+
+    const actionsShouldBeDisabled = !(userContext?.hasAgreedToTermsOfService ?? false);
 
     const notPaired = (
         <Grid container item xs={6} justify='center'>
@@ -27,7 +31,7 @@ const MockInterview: FC = () => {
     const paired = (
         <Grid container item xs={6} justify='center'>
             <Typography align='center'>
-                You have been paired with an interviewer. Go to there <Link href={calendlyLink}>Calendly link</Link> to find a time for a mock interview.
+                You have been paired with an interviewer. Go to there {actionsShouldBeDisabled ? 'hidden link' : <Link href={calendlyLink}>Calendly link</Link>} to find a time for a mock interview.
             </Typography>
         </Grid>
     );

--- a/www/src/routes/student/resumeReview/MockInterview.test.tsx
+++ b/www/src/routes/student/resumeReview/MockInterview.test.tsx
@@ -1,0 +1,41 @@
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { mocked } from 'ts-jest/utils';
+
+import { SubsetUserState } from '../../../contexts/UserContext';
+import useUserContext from '../../../hooks/useUserContext';
+import { useStudentSelector } from '../../../redux/substores/student/studentHooks';
+import testConstants from '../../../util/testConstants';
+import MockInterview from '../MockInterview';
+
+jest.mock('../../../hooks/useUserContext');
+const mockUseUserContext = mocked(useUserContext, true);
+
+jest.mock('../../../redux/substores/student/studentHooks');
+const mockUseStudentSelector = mocked(useStudentSelector, true);
+
+describe('MockInterview', () => {
+    beforeEach(() => {
+        mockUseStudentSelector.mockReturnValue(testConstants.studentState);
+    });
+
+    it('disables the submit button when user has not agreed to terms of service', () => {
+        mockUseUserContext.mockReturnValueOnce({
+            hasAgreedToTermsOfService: false,
+        } as SubsetUserState);
+
+        const result = shallow(<MockInterview />);
+        expect(result.find(Button)).toHaveLength(0);
+    });
+
+    it('disables the text field when user has not agreed to terms of service', () => {
+        mockUseUserContext.mockReturnValueOnce({
+            hasAgreedToTermsOfService: false,
+        } as SubsetUserState);
+
+        const result = shallow(<MockInterview />);
+        expect(result.find(TextField)).toHaveLength(0);
+    });
+});

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.test.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.test.tsx
@@ -1,8 +1,11 @@
+import Button from '@material-ui/core/Button';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { shallow } from 'enzyme';
 import React from 'react';
 import { mocked } from 'ts-jest/utils';
 
+import { SubsetUserState } from '../../../contexts/UserContext';
+import useUserContext from '../../../hooks/useUserContext';
 import { useStudentDispatch, useStudentSelector } from '../../../redux/substores/student/studentHooks';
 import testConstants from '../../../util/testConstants';
 import ResumeReviewCard from './ResumeReviewCard';
@@ -11,9 +14,14 @@ jest.mock('../../../redux/substores/student/studentHooks');
 const mockUseStudentDispatch = mocked(useStudentDispatch, true);
 const mockUseStudentSelector = mocked(useStudentSelector, true);
 
+jest.mock('../../../hooks/useUserContext');
+const mockUseUserContext = mocked(useUserContext, true);
+
 beforeEach(() => {
     const mockStudentState = testConstants.studentState;
     mockUseStudentSelector.mockImplementation((selector) => selector(mockStudentState));
+
+    mockUseUserContext.mockReturnValue(testConstants.subsetUser1);
 
     mockUseStudentDispatch.mockReturnValue(jest.fn());
 });
@@ -58,4 +66,22 @@ it.each(['cancelled', 'finished', 'reviewing', 'seeking_reviewer'])('displays th
     } else {
         expect(result.find(ExpandMoreIcon)).toHaveLength(0);
     }
+});
+
+it('disables cancel review when user has not agreed to terms of service', () => {
+    const mockResumeReview = testConstants.resumeReview1;
+
+    mockUseUserContext.mockReturnValueOnce({
+        hasAgreedToTermsOfService: false,
+    } as SubsetUserState);
+
+    const result = shallow(<ResumeReviewCard resumeReview={mockResumeReview} />);
+
+    expect(
+        result
+            .find(Button)
+            .findWhere((n) => n.text() === 'Cancel review')
+            .first()
+            .prop('disabled'),
+    ).toBe(true);
 });

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -5,8 +5,9 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import clsx from 'clsx';
 import dateFormat from 'dateformat';
-import React, { FC, useState } from 'react';
+import React, { FC, useContext, useState } from 'react';
 
+import UserContext from '../../../contexts/UserContext';
 import { useStudentDispatch } from '../../../redux/substores/student/studentHooks';
 import cancelResumeReview from '../../../redux/substores/student/thunks/cancelResumeReview';
 import fetchWithToken from '../../../util/auth0/fetchWithToken';
@@ -44,6 +45,7 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
     const [isExpanded, setIsExpanded] = useState(false);
     const dispatch = useStudentDispatch();
 
+    const userContext = useContext(UserContext);
     const { getAccessTokenSilently } = useAuth0();
 
     const stateToDisplayNameMap = new Map([
@@ -52,6 +54,8 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
         ['reviewing', 'In review'],
         ['seeking_reviewer', 'Pending'],
     ]);
+
+    const shouldBeDisabled = !userContext?.hasAgreedToTermsOfService ?? false;
 
     return (
         <Card className={classes.currentResumeCard} elevation={0}>
@@ -76,6 +80,7 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
                             onClick={() => {
                                 dispatch(cancelResumeReview({ resumeReviewId: resumeReview.id, tokenAcquirer: getAccessTokenSilently }));
                             }}
+                            disabled={shouldBeDisabled}
                         >
                             Cancel review
                         </Button>

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -55,7 +55,7 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
         ['seeking_reviewer', 'Pending'],
     ]);
 
-    const shouldBeDisabled = !userContext?.hasAgreedToTermsOfService ?? false;
+    const actionsShouldBeDisabled = !userContext?.hasAgreedToTermsOfService ?? false;
 
     return (
         <Card className={classes.currentResumeCard} elevation={0}>
@@ -80,7 +80,7 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
                             onClick={() => {
                                 dispatch(cancelResumeReview({ resumeReviewId: resumeReview.id, tokenAcquirer: getAccessTokenSilently }));
                             }}
-                            disabled={shouldBeDisabled}
+                            disabled={actionsShouldBeDisabled}
                         >
                             Cancel review
                         </Button>

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -5,9 +5,9 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import clsx from 'clsx';
 import dateFormat from 'dateformat';
-import React, { FC, useContext, useState } from 'react';
+import React, { FC, useState } from 'react';
 
-import UserContext from '../../../contexts/UserContext';
+import useUserContext from '../../../hooks/useUserContext';
 import { useStudentDispatch } from '../../../redux/substores/student/studentHooks';
 import cancelResumeReview from '../../../redux/substores/student/thunks/cancelResumeReview';
 import fetchWithToken from '../../../util/auth0/fetchWithToken';
@@ -44,8 +44,8 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
     const classes = useStyles();
     const [isExpanded, setIsExpanded] = useState(false);
     const dispatch = useStudentDispatch();
+    const userContext = useUserContext();
 
-    const userContext = useContext(UserContext);
     const { getAccessTokenSilently } = useAuth0();
 
     const stateToDisplayNameMap = new Map([

--- a/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
+++ b/www/src/routes/student/resumeReview/ResumeReviewCard.tsx
@@ -55,7 +55,7 @@ const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resumeReview }: ResumeRev
         ['seeking_reviewer', 'Pending'],
     ]);
 
-    const actionsShouldBeDisabled = !userContext?.hasAgreedToTermsOfService ?? false;
+    const actionsShouldBeDisabled = !(userContext?.hasAgreedToTermsOfService ?? false);
 
     return (
         <Card className={classes.currentResumeCard} elevation={0}>

--- a/www/src/routes/student/resumeReview/UploadResume.tsx
+++ b/www/src/routes/student/resumeReview/UploadResume.tsx
@@ -5,11 +5,11 @@ import { fade } from '@material-ui/core/styles/colorManipulator';
 import { Cancel, CheckCircle } from '@material-ui/icons';
 import PublishIcon from '@material-ui/icons/Publish';
 import clsx from 'clsx';
-import React, { FC, useCallback, useContext, useEffect } from 'react';
+import React, { FC, useCallback, useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
 
 import PDFViewer from '../../../components/pdf/PDFViewer';
-import UserContext from '../../../contexts/UserContext';
+import useUserContext from '../../../hooks/useUserContext';
 import { setIsUploadingResume } from '../../../redux/substores/student/slices/resumeReviewSlice';
 import { resetUploadResume, setDocument } from '../../../redux/substores/student/slices/uploadResumeSlice';
 import { useStudentDispatch, useStudentSelector } from '../../../redux/substores/student/studentHooks';
@@ -56,7 +56,7 @@ const UploadResume: FC = () => {
     const dispatch = useStudentDispatch();
     const { user, getAccessTokenSilently } = useAuth0();
     const { document, isLoading, isUploadComplete } = useStudentSelector((state) => state.uploadResume);
-    const userContext = useContext(UserContext);
+    const userContext = useUserContext();
 
     useEffect(() => {
         // Reset when user revisits this page

--- a/www/src/routes/student/resumeReview/UploadResume.tsx
+++ b/www/src/routes/student/resumeReview/UploadResume.tsx
@@ -76,18 +76,18 @@ const UploadResume: FC = () => {
         handleOnFileSelected(dispatch, acceptedFiles);
     }, []);
 
-    const shouldBeDisabled = !(userContext?.hasAgreedToTermsOfService ?? false);
-    const { getRootProps, getInputProps } = useDropzone({ onDrop, disabled: shouldBeDisabled });
+    const actionsShouldBeDisabled = !(userContext?.hasAgreedToTermsOfService ?? false);
+    const { getRootProps, getInputProps } = useDropzone({ onDrop, disabled: actionsShouldBeDisabled });
 
     if (document === null) {
         return (
             <Grid container item xs={12} justify='center'>
-                <div {...getRootProps()} className={clsx(shouldBeDisabled ? classes.uploadBoxDisabled : classes.uploadBox)}>
+                <div {...getRootProps()} className={clsx(actionsShouldBeDisabled ? classes.uploadBoxDisabled : classes.uploadBox)}>
                     <input {...getInputProps()} />
                     <Box display='flex' alignItems='center'>
                         <PublishIcon className={classes.uploadIcon} />
                         <Typography>Drag and Drop or </Typography>
-                        <div className={shouldBeDisabled ? classes.browseButtonDisabled : classes.browseButton}>
+                        <div className={actionsShouldBeDisabled ? classes.browseButtonDisabled : classes.browseButton}>
                             <Typography>Browse computer</Typography>
                         </div>
                     </Box>

--- a/www/src/routes/volunteer/MockInterview.tsx
+++ b/www/src/routes/volunteer/MockInterview.tsx
@@ -1,9 +1,10 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { Button, Grid, Link, makeStyles, TextField, Typography } from '@material-ui/core';
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useContext, useEffect, useState } from 'react';
 
 import GiveAvailabilityIcon from '../../assets/give_availability.svg';
 import LoadingOverlay from '../../components/LoadingOverlay';
+import UserContext from '../../contexts/UserContext';
 import getCalendlyLink from '../../redux/substores/volunteer/thunks/getCalendlyLink';
 import setCalendlyLink from '../../redux/substores/volunteer/thunks/setCalendlyLink';
 import { useVolunteerDispatch, useVolunteerSelector } from '../../redux/substores/volunteer/volunteerHooks';
@@ -14,12 +15,15 @@ const MockInterview: FC = () => {
     const dispatch = useVolunteerDispatch();
     const { getAccessTokenSilently, user } = useAuth0();
     const [calendlyInput, setCalendlyInput] = useState<string>('');
+    const userContext = useContext(UserContext);
 
     useEffect(() => {
         if (user?.sub !== undefined) {
             dispatch(getCalendlyLink({ tokenAcquirer: getAccessTokenSilently, interviewerId: user.sub }));
         }
     }, [user]);
+
+    const actionsShouldBeDisabled = !(userContext?.hasAgreedToTermsOfService ?? false);
 
     const submitLink = (
         <>
@@ -37,10 +41,12 @@ const MockInterview: FC = () => {
                     InputLabelProps={{ className: classes.label }}
                     value={calendlyInput}
                     onChange={(e) => setCalendlyInput(e.target.value)}
+                    disabled={actionsShouldBeDisabled}
                 />
                 <Button
                     variant='contained'
                     color='primary'
+                    disabled={actionsShouldBeDisabled}
                     onClick={() => {
                         if (user?.sub !== undefined) {
                             dispatch(setCalendlyLink({ tokenAcquirer: getAccessTokenSilently, interviewerId: user.sub, link: calendlyInput }));

--- a/www/src/routes/volunteer/MockInterview.tsx
+++ b/www/src/routes/volunteer/MockInterview.tsx
@@ -1,10 +1,10 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { Button, Grid, Link, makeStyles, TextField, Typography } from '@material-ui/core';
-import React, { FC, useContext, useEffect, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 
 import GiveAvailabilityIcon from '../../assets/give_availability.svg';
 import LoadingOverlay from '../../components/LoadingOverlay';
-import UserContext from '../../contexts/UserContext';
+import useUserContext from '../../hooks/useUserContext';
 import getCalendlyLink from '../../redux/substores/volunteer/thunks/getCalendlyLink';
 import setCalendlyLink from '../../redux/substores/volunteer/thunks/setCalendlyLink';
 import { useVolunteerDispatch, useVolunteerSelector } from '../../redux/substores/volunteer/volunteerHooks';
@@ -15,7 +15,7 @@ const MockInterview: FC = () => {
     const dispatch = useVolunteerDispatch();
     const { getAccessTokenSilently, user } = useAuth0();
     const [calendlyInput, setCalendlyInput] = useState<string>('');
-    const userContext = useContext(UserContext);
+    const userContext = useUserContext();
 
     useEffect(() => {
         if (user?.sub !== undefined) {

--- a/www/src/routes/volunteer/ResumeReview.test.tsx
+++ b/www/src/routes/volunteer/ResumeReview.test.tsx
@@ -1,0 +1,45 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { mocked } from 'ts-jest/utils';
+
+import { SubsetUserState } from '../../contexts/UserContext';
+import useUserContext from '../../hooks/useUserContext';
+import { useVolunteerDispatch, useVolunteerSelector } from '../../redux/substores/volunteer/volunteerHooks';
+import testConstants from '../../util/testConstants';
+import ResumeReview from './ResumeReview';
+import ResumeReviewTable from './ResumeReviewTable';
+
+jest.mock('../../redux/substores/volunteer/volunteerHooks');
+const mockUseVolunteerSelector = mocked(useVolunteerSelector, true);
+const mockUseVolunteerDispatch = mocked(useVolunteerDispatch, true);
+
+jest.mock('../../hooks/useUserContext');
+const mockUseUserContext = mocked(useUserContext, true);
+const mockDispatch = jest.fn();
+
+beforeEach(() => {
+    mockUseVolunteerSelector.mockImplementation((selector) => selector(testConstants.volunteerState));
+    mockUseVolunteerDispatch.mockImplementation(mockDispatch);
+
+    jest.clearAllMocks();
+});
+
+it('disables table actions when user has not agreed to terms of service', () => {
+    mockUseUserContext.mockReturnValueOnce({
+        hasAgreedToTermsOfService: false,
+    } as SubsetUserState);
+    const mockVolunteerState = testConstants.volunteerState;
+    mockVolunteerState.resumeReview.availableResumes = [testConstants.resumeReviewWithUserDetails1];
+    mockVolunteerState.resumeReview.reviewingResumes = [testConstants.resumeReviewWithUserDetails1];
+
+    const result = shallow(<ResumeReview />);
+
+    const tables = result.find(ResumeReviewTable);
+    expect(tables).toHaveLength(2);
+    tables.forEach((tableComponent) => {
+        const actions = tableComponent.prop('actions');
+        for (const action of actions) {
+            expect(action.disabled).toBe(true);
+        }
+    });
+});

--- a/www/src/routes/volunteer/ResumeReview.tsx
+++ b/www/src/routes/volunteer/ResumeReview.tsx
@@ -2,11 +2,11 @@ import { useAuth0 } from '@auth0/auth0-react';
 import { Button, CircularProgress, Grid, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import RefreshIcon from '@material-ui/icons/Refresh';
-import React, { FC, useContext, useEffect } from 'react';
+import React, { FC, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import TitledPage from '../../components/TitledPage';
-import UserContext from '../../contexts/UserContext';
+import useUserContext from '../../hooks/useUserContext';
 import { refreshResumeReviews } from '../../redux/substores/volunteer/slices/resumeReviewSlice';
 import claimResumeReviews from '../../redux/substores/volunteer/thunks/claimResumeReviews';
 import getAvailableResumeReviews from '../../redux/substores/volunteer/thunks/getAvailableResumeReviews';
@@ -22,7 +22,7 @@ const ResumeReview: FC = () => {
     const dispatch = useVolunteerDispatch();
     const classes = useStyles();
     const history = useHistory();
-    const userContext = useContext(UserContext);
+    const userContext = useUserContext();
 
     useEffect(() => {
         if (user?.sub !== undefined && shouldReload) {

--- a/www/src/routes/volunteer/ResumeReviewEditor.tsx
+++ b/www/src/routes/volunteer/ResumeReviewEditor.tsx
@@ -65,7 +65,7 @@ const ResumeReviewEditor: React.FC = () => {
         return base64ToArrayBuffer(currentDocument?.base64Contents);
     };
 
-    const actionsShouldBeDisabled = !userContext?.hasAgreedToTermsOfService ?? false;
+    const actionsShouldBeDisabled = !(userContext?.hasAgreedToTermsOfService ?? false);
 
     return (
         <>

--- a/www/src/routes/volunteer/ResumeReviewEditor.tsx
+++ b/www/src/routes/volunteer/ResumeReviewEditor.tsx
@@ -7,6 +7,7 @@ import { useHistory, useParams } from 'react-router-dom';
 
 import LoadingOverlay from '../../components/LoadingOverlay';
 import PDFViewer from '../../components/pdf/PDFViewer';
+import useUserContext from '../../hooks/useUserContext';
 import { resetResumeReviewEditor } from '../../redux/substores/volunteer/slices/resumeReviewEditorSlice';
 import getReviewingResumeReviews from '../../redux/substores/volunteer/thunks/getReviewingResumeReviews';
 import { useVolunteerDispatch, useVolunteerSelector } from '../../redux/substores/volunteer/volunteerHooks';
@@ -30,6 +31,7 @@ const ResumeReviewEditor: React.FC = () => {
     const { getAccessTokenSilently, user } = useAuth0();
     const history = useHistory();
     const dispatch = useVolunteerDispatch();
+    const userContext = useUserContext();
 
     const currentResumeReview = reviewingResumes.find((review) => review.id === resumeReviewId);
 
@@ -63,6 +65,8 @@ const ResumeReviewEditor: React.FC = () => {
         return base64ToArrayBuffer(currentDocument?.base64Contents);
     };
 
+    const actionsShouldBeDisabled = !userContext?.hasAgreedToTermsOfService ?? false;
+
     return (
         <>
             <LoadingOverlay open={isLoading || reviewingIsLoading || (isResumeReviewPatched && !isDocumentPatched)} />
@@ -76,6 +80,7 @@ const ResumeReviewEditor: React.FC = () => {
                             variant='contained'
                             color='primary'
                             endIcon={<DoneIcon />}
+                            disabled={actionsShouldBeDisabled}
                             onClick={() =>
                                 dispatch(
                                     patchResumeReview({

--- a/www/src/routes/volunteer/ResumeReviewTable.tsx
+++ b/www/src/routes/volunteer/ResumeReviewTable.tsx
@@ -8,6 +8,7 @@ import { ResumeReviewWithUserDetails as RRWUD } from '../../util/serverResponses
 interface Action {
     name: string;
     func: (resumeReview: RRWUD) => void;
+    disabled?: boolean;
 }
 
 interface ResumeReviewTableProps {
@@ -40,7 +41,7 @@ const ResumeReviewTable: FC<ResumeReviewTableProps> = (props: ResumeReviewTableP
                                     <ButtonGroup>
                                         {props.actions.map((action) => {
                                             return (
-                                                <Button key={action.name} onClick={() => action.func(resume)}>
+                                                <Button key={action.name} onClick={() => action.func(resume)} disabled={action.disabled}>
                                                     {action.name}
                                                 </Button>
                                             );

--- a/www/src/util/testConstants.ts
+++ b/www/src/util/testConstants.ts
@@ -1,7 +1,8 @@
+import { SubsetUserState } from '../contexts/UserContext';
 import { RootState } from '../redux/store';
 import { StudentState } from '../redux/substores/student/studentStore';
 import { VolunteerState } from '../redux/substores/volunteer/volunteerStore';
-import { Document, ResumeReview, Role, User } from './serverResponses';
+import { Document, ResumeReview, ResumeReviewWithUserDetails, Role, User } from './serverResponses';
 
 const user1: User = {
     id: 'google-oauth2|999937999992352499990',
@@ -25,6 +26,17 @@ const resumeReview1: ResumeReview = {
     state: 'seeking_reviewer',
     createdAt: '2021-06-14T06:09:19.373404+00:00',
     updatedAt: '2021-06-14T06:09:19.373404+00:00',
+};
+
+const resumeReviewWithUserDetails1: ResumeReviewWithUserDetails = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    revieweeId: user1.id,
+    reviewerId: null,
+    state: 'seeking_reviewer',
+    createdAt: '2021-06-14T06:09:19.373404+00:00',
+    updatedAt: '2021-06-14T06:09:19.373404+00:00',
+    reviewer: user1,
+    reviewee: user1,
 };
 
 const document1: Document = {
@@ -107,4 +119,10 @@ const volunteerState: VolunteerState = {
     },
 };
 
-export default { user1, resumeReview1, document1, globalState, studentState, volunteerState, studentRole };
+const subsetUser1: SubsetUserState = {
+    currentRole: 'student',
+    hasAgreedToTermsOfService: true,
+    roles: ['student', 'reviewer', 'interviewer'],
+};
+
+export default { user1, resumeReview1, resumeReviewWithUserDetails1, document1, globalState, studentState, volunteerState, studentRole, subsetUser1 };


### PR DESCRIPTION
# Overview

Disable the following actions for users who have not agreed to our terms of service
* For students
  * Requesting/cancelling resume reviews
  * Getting their calendly links
* For volunteers
  * Claiming/unclaiming/reviewing resumes
  * Uploading a mock interview link

# Changes

* Create a custom user context because the global store isn't working as expected
  * TL;DR you can only have one store provider, once we go into the student/volunteer apps, we can no longer access the global store 
* Disable buttons when user hasn't agreed to our terms of service
* Hide links when user hasn't agreed to our terms of service
* Disable hover and interaction for upload resume when user hasn't agreed to our terms of service

# Questions & Notes

* How to best hide the hidden link in the mock interview page?

* Best to merge #289 first so that users can actually do something to reenable the interactions

# Issue tracking

Closes #288 

# Testing & Demo

![image](https://user-images.githubusercontent.com/43416725/141734212-fc9d1c3c-6a56-4094-bd31-08413c69954d.png)