### PR TITLE
Hide terms of service alert for unauthenticated users

### DIFF
--- a/www/src/App.test.tsx
+++ b/www/src/App.test.tsx
@@ -1,12 +1,13 @@
 import { Auth0ContextInterface, useAuth0, User } from '@auth0/auth0-react';
 import { AsyncThunkAction } from '@reduxjs/toolkit';
 import { render } from '@testing-library/react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import React from 'react';
 import { mocked } from 'ts-jest/utils';
 
 import App from './App';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
+import { reset } from './redux/slices/userSlice';
 import { AppDispatch, RootState } from './redux/store';
 import fetchUserInfo from './redux/thunks/fetchUserInfo';
 import getUserRole, { GetUserRoleParameters, GetUserRolesResponse } from './redux/thunks/getUserRole';
@@ -115,6 +116,22 @@ describe('App', () => {
             expect(mockDispatch).toBeCalledWith(mockAction);
         } else {
             expect(mockDispatch).not.toBeCalledWith(mockAction);
+        }
+    });
+
+    it.each([true, false])('calls reset user state only when user is unauthenticated', (isAuthenticated) => {
+        mockAuth0State = {
+            isAuthenticated,
+            isLoading: false,
+        } as unknown as Auth0ContextInterface<User>;
+        mockUseAuth0.mockReturnValueOnce(mockAuth0State);
+
+        mount(<App />);
+
+        if (isAuthenticated) {
+            expect(mockDispatch).not.toBeCalledWith(reset());
+        } else {
+            expect(mockDispatch).toBeCalledWith(reset());
         }
     });
 });

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -11,6 +11,7 @@ import TermsOfServiceAlert from './components/TermsOfServiceAlert';
 import SettingsDialog from './components/user/SettingsDialog';
 import TermsOfServiceDialog from './components/user/TermsOfServiceDialog';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
+import { reset } from './redux/slices/userSlice';
 import fetchUserInfo from './redux/thunks/fetchUserInfo';
 import getUserRole from './redux/thunks/getUserRole';
 import AdminApp from './routes/Admin';
@@ -51,6 +52,8 @@ const App: FC = () => {
     useEffect(() => {
         if (isAuthenticated) {
             dispatch(fetchUserInfo(getAccessTokenSilently));
+        } else {
+            dispatch(reset());
         }
     }, [isAuthenticated]);
 

--- a/www/src/components/TermsOfServiceAlert.test.tsx
+++ b/www/src/components/TermsOfServiceAlert.test.tsx
@@ -1,0 +1,50 @@
+import { Auth0ContextInterface, useAuth0, User } from '@auth0/auth0-react';
+import Snackbar from '@material-ui/core/Snackbar';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { mocked } from 'ts-jest/utils';
+
+import { useAppDispatch, useAppSelector } from '../redux/hooks';
+import { UserState } from '../redux/slices/userSlice';
+import { AppDispatch } from '../redux/store';
+import testConstants from '../util/testConstants';
+import TermsOfServiceAlert from './TermsOfServiceAlert';
+
+jest.mock('@auth0/auth0-react');
+const mockUseAuth0 = mocked(useAuth0, true);
+
+jest.mock('../redux/hooks');
+const mockUseAppSelector = mocked(useAppSelector, true);
+const mockUseAppDispatch = mocked(useAppDispatch, true);
+
+let mockDispatch: jest.MockedFunction<AppDispatch>;
+
+beforeEach(() => {
+    mockDispatch = jest.fn();
+    mockUseAppDispatch.mockReturnValue(mockDispatch);
+
+    jest.clearAllMocks();
+});
+
+it.each`
+    isAuthenticated | hasAgreedToTermsOfService
+    ${false}        | ${false}
+    ${false}        | ${true}
+    ${true}         | ${false}
+    ${true}         | ${true}
+`('shows alert only for authenticated users that have not agreed to terms of service', ({ isAuthenticated, hasAgreedToTermsOfService }) => {
+    mockUseAuth0.mockReturnValueOnce({
+        isAuthenticated,
+    } as unknown as Auth0ContextInterface<User>);
+
+    const mockGlobalState = testConstants.globalState;
+    mockGlobalState.user = {
+        hasAgreedToTermsOfService,
+    } as UserState;
+    mockUseAppSelector.mockImplementationOnce((selector) => selector(mockGlobalState));
+
+    const shouldBeOpen = isAuthenticated && !hasAgreedToTermsOfService;
+
+    const result = shallow(<TermsOfServiceAlert />);
+    expect(result.find(Snackbar).prop('open')).toBe(shouldBeOpen);
+});

--- a/www/src/components/TermsOfServiceAlert.tsx
+++ b/www/src/components/TermsOfServiceAlert.tsx
@@ -1,3 +1,4 @@
+import { useAuth0 } from '@auth0/auth0-react';
 import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import Snackbar from '@material-ui/core/Snackbar';
@@ -8,15 +9,20 @@ import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { openTermsOfServiceDialog } from '../redux/slices/userSlice';
 
 const TermsOfServiceAlert: FC = () => {
+    const { isAuthenticated } = useAuth0();
     const { hasAgreedToTermsOfService } = useAppSelector((state) => state.user);
-    const [isOpen, setIsOpen] = useState(!hasAgreedToTermsOfService);
+    const [isOpen, setIsOpen] = useState(isAuthenticated && !hasAgreedToTermsOfService);
     const dispatch = useAppDispatch();
 
     useEffect(() => {
-        if (hasAgreedToTermsOfService) {
-            setIsOpen(false);
+        if (isAuthenticated) {
+            if (hasAgreedToTermsOfService) {
+                setIsOpen(false);
+            } else {
+                setIsOpen(true);
+            }
         }
-    }, [hasAgreedToTermsOfService]);
+    }, [hasAgreedToTermsOfService, isAuthenticated]);
 
     const handleClose = () => {
         setIsOpen(false);

--- a/www/src/components/auth/UserProfile.tsx
+++ b/www/src/components/auth/UserProfile.tsx
@@ -5,7 +5,7 @@ import { AccountCircle } from '@material-ui/icons';
 import React, { FC, useRef } from 'react';
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
-import { closeUserProfileDialog, openEditRolesDialog, openUserProfileDialog, reset } from '../../redux/slices/userSlice';
+import { closeUserProfileDialog, openEditRolesDialog, openUserProfileDialog } from '../../redux/slices/userSlice';
 
 const UserProfile: FC = () => {
     const classes = useStyles();

--- a/www/src/components/auth/UserProfile.tsx
+++ b/www/src/components/auth/UserProfile.tsx
@@ -17,7 +17,6 @@ const UserProfile: FC = () => {
     const dispatch = useAppDispatch();
 
     const handleLogout = () => {
-        dispatch(reset());
         logout();
     };
 

--- a/www/src/redux/slices/userSlice.ts
+++ b/www/src/redux/slices/userSlice.ts
@@ -4,7 +4,7 @@ import fetchUserInfo from '../thunks/fetchUserInfo';
 import getUserRole from '../thunks/getUserRole';
 import patchUser from '../thunks/patchUser';
 
-type UserState = {
+export type UserState = {
     roles: string[];
     currentRole: string;
     hasAgreedToTermsOfService: boolean | null;


### PR DESCRIPTION
# Overview

Terms of service alert is currently displayed to all users (authenticated or not) because there was no check for this. We only checked if the user has agreed to terms of service and undefined is a falsy value.

Also clear persisted user information when the user is logged out (either through the Logout button or automatically due to JWT expiry)

# Changes

* Add check for authentication status in terms of service alert component
* Simulate clearing the user state when the user is logged out

# Questions & Notes


# Issue tracking



# Testing & Demo

1. From master branch, comment out `dispatch(reset())` in UserProfile
2. Log-in to local.compe.plus
3. Log-out
4. Open resume review page and verify that you have your previous view (you can also double check your local storage and see that the current role is not "")
5. Add the `dispatch(reset())` call to App.tsx when the user is not authenticated
6. Refresh the page and your current role should be cleared